### PR TITLE
Fix compile command

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -21,8 +21,13 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import {Option} from 'commander';
 import {runOrCompile} from '../malloy/util';
 
-export async function compileCommand(source: string, options): Promise<void> {
-  await runOrCompile(source, options, true);
+export async function compileCommand(
+  source: string,
+  query: string | undefined,
+  options: Option[]
+): Promise<void> {
+  await runOrCompile(source, query, options, true);
 }


### PR DESCRIPTION
Compile command was mixing up options and query name which also caused the compileOnly flag to be ignored.