### PR TITLE
Add a run config option to Launch CLI with ts-node

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,16 @@
       "outFiles": ["${workspaceFolder}/dist/**/*.js"],
       "args": "${input:cli-command}",
       "console": "integratedTerminal"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch CLI (ts-node)",
+      "skipFiles": ["<node_internals>/**"],
+      "program": "${workspaceFolder}/src/index.ts",
+      "runtimeArgs": ["-r", "ts-node/register"],
+      "args": "${input:cli-command}",
+      "console": "integratedTerminal"
     }
   ],
   "inputs": [


### PR DESCRIPTION
This is useful when the build-task is broken or in any situation where running directly via ts-node is preferred