### PR TITLE
use a GitHub App for authentication, add proper failure summaries

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -48,7 +48,8 @@ jobs:
         env:
           NODE_AUTH_TOKEN: "${{ secrets.NPM_TOKEN }}"
       
-      - name: Summary
+      - name: Success Summary
+        if: success()
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
           GIT_SHA=$(git rev-parse --short=7 HEAD)
@@ -61,8 +62,19 @@ jobs:
           echo "- **Version**: ${NEXT_VERSION}" >> $GITHUB_STEP_SUMMARY
           echo "- **Base Version**: ${PACKAGE_VERSION}" >> $GITHUB_STEP_SUMMARY
           echo "- **Commit**: ${GIT_SHA}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Status**: ✅ Successfully published" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Install with: \`npm install @malloydata/cli@next\`" >> $GITHUB_STEP_SUMMARY
+      
+      - name: Failure Summary
+        if: failure()
+        run: |
+          echo "## 📋 Publishing Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Mode**: 🚀 Publish to @next" >> $GITHUB_STEP_SUMMARY
+          echo "- **Status**: ❌ Publishing failed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Check the workflow logs for details." >> $GITHUB_STEP_SUMMARY
 
   publish-latest:
     # Only run on manual workflow dispatch
@@ -72,9 +84,16 @@ jobs:
       contents: write  # Needed to push commits and tags
       packages: read
     steps:
+      - name: Generate token from GitHub App
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.NPM_ACTIONS_APP_ID }}
+          private-key: ${{ secrets.NPM_ACTIONS_PRIVATE_KEY }}
+      
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GHAPI_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
       
       - uses: actions/setup-node@v4
         with:
@@ -101,7 +120,7 @@ jobs:
       - name: Verify push permissions
         if: inputs.dry_run == false
         env:
-          CHECK_TOKEN: ${{ secrets.GHAPI_PAT }}
+          CHECK_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "🔐 Verifying repository push permissions..."
           RESPONSE=$(curl -s -H "Authorization: token $CHECK_TOKEN" \
@@ -130,7 +149,8 @@ jobs:
         env:
           NODE_AUTH_TOKEN: "${{ secrets.NPM_TOKEN }}"
       
-      - name: Summary
+      - name: Success Summary
+        if: success()
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
           
@@ -146,3 +166,14 @@ jobs:
           else
             echo "- **Status**: ✅ Tested successfully (no changes made)" >> $GITHUB_STEP_SUMMARY
           fi
+      
+      - name: Failure Summary
+        if: failure()
+        run: |
+          echo "## 📋 Publishing Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Mode**: ${{ inputs.dry_run && '🧪 Dry Run' || '🚀 Live Publishing' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Bump Type**: patch" >> $GITHUB_STEP_SUMMARY
+          echo "- **Status**: ❌ Publishing failed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Check the workflow logs for details." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test-git-permissions.yml
+++ b/.github/workflows/test-git-permissions.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       use_pat:
-        description: 'Use GHAPI_PAT token'
+        description: 'Use GitHub App token'
         required: false
         default: false
         type: boolean
@@ -15,37 +15,27 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Debug token availability
+      - name: Generate token from GitHub App
         if: inputs.use_pat == true
-        env:
-          CHECK_TOKEN: ${{ secrets.GHAPI_PAT }}
-        run: |
-          if [ -z "$CHECK_TOKEN" ]; then
-            echo "❌ ERROR: GHAPI_PAT secret is empty or not set!"
-            exit 1
-          fi
-          
-          # Check token format (should start with github_pat_ or ghp_)
-          if [[ ! "$CHECK_TOKEN" =~ ^(github_pat_|ghp_) ]]; then
-            echo "⚠️  WARNING: Token doesn't match expected GitHub PAT format"
-            echo "Token starts with: ${CHECK_TOKEN:0:10}..."
-          else
-            echo "✅ Token format looks correct: ${CHECK_TOKEN:0:11}..."
-          fi
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.NPM_ACTIONS_APP_ID }}
+          private-key: ${{ secrets.NPM_ACTIONS_PRIVATE_KEY }}
       
       - name: Checkout (with GITHUB_TOKEN)
         if: inputs.use_pat == false
         uses: actions/checkout@v4
       
-      - name: Checkout (with PAT)
+      - name: Checkout (with GitHub App token)
         if: inputs.use_pat == true
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GHAPI_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
       
       - name: Check push permissions via GitHub API
         env:
-          CHECK_TOKEN: ${{ inputs.use_pat == true && secrets.GHAPI_PAT || secrets.GITHUB_TOKEN }}
+          CHECK_TOKEN: ${{ inputs.use_pat == true && steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
         run: |
           echo "Checking repository permissions via GitHub API..."
           
@@ -93,7 +83,7 @@ jobs:
           # Write success to summary
           echo "## 🔐 Git Permission Test Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Auth Method**: ${{ inputs.use_pat && 'GHAPI_PAT Token' || 'GITHUB_TOKEN' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Auth Method**: ${{ inputs.use_pat && 'GitHub App Token' || 'GITHUB_TOKEN' }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Result**: ✅ Push permissions verified" >> $GITHUB_STEP_SUMMARY
       
       - name: Failure Summary
@@ -101,5 +91,5 @@ jobs:
         run: |
           echo "## 🔐 Git Permission Test Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Auth Method**: ${{ inputs.use_pat && 'GHAPI_PAT Token' || 'GITHUB_TOKEN' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Auth Method**: ${{ inputs.use_pat && 'GitHub App Token' || 'GITHUB_TOKEN' }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Result**: ❌ Permission check failed" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
- Replace PAT token with GitHub App authentication
- Add proper success/failure summaries to all three workflows
- Update test workflow to use GitHub App token generation
- Update publish workflows to show correct status in summaries