### PR TITLE
feat: add MotherDuck support to CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -231,7 +231,17 @@ export function createCLI(): Command {
     .command('create-duckdb')
     .description('add a new DuckDB database connection')
     .argument('<name>')
-    .option('-d, --database-path <database>')
+    .addOption(
+      new Option(
+        '--database-path <database>',
+        'path to DuckDB database file or MotherDuck database (e.g., "md:my_database")'
+      )
+    )
+    .addOption(
+      new Option('--mother-duck-token <token>', 'MotherDuck API token').env(
+        'MOTHERDUCK_TOKEN'
+      )
+    )
     .action(createDuckDbConnectionCommand);
 
   connections


### PR DESCRIPTION
## Summary

- Add `--database-path` and `--mother-duck-token` options to the `create-duckdb` command to enable MotherDuck connections
- Removed `-d` short option to avoid conflict with global `--debug` flag
- Add `additionalExtensions` field to DuckDBConnectionOptions/Config for feature parity with the core library
- Document MotherDuck usage in README with examples

## Usage

```bash
# With explicit token
malloy-cli connections create-duckdb my-motherduck \
  --database-path "md:my_database" \
  --mother-duck-token "your_token"

# With environment variable
export MOTHERDUCK_TOKEN="your_token"
malloy-cli connections create-duckdb my-motherduck --database-path "md:"
```

## Test plan

- [x] Tested locally with MotherDuck sample_data database
- [x] Connection test passes
- [x] Query execution returns results from MotherDuck
- [x] Existing unit tests pass (BigQuery tests timeout as expected without credentials)