### PR TITLE
Add build command for persistent tables

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,7 @@ import {createBasicLogger, silenceOut} from './log';
 import {loadConnections} from './connections/connection_manager';
 import {showThirdPartyCommand} from './commands/third_party';
 import {compileCommand} from './commands/compile';
+import {buildCommand} from './commands/build';
 
 const compileDescription = `compile a Malloy file (.malloy or .malloysql)
 
@@ -100,6 +101,12 @@ export function createCLI(): Command {
       new Option('-l, --log-level <level>', 'log level')
         .choices(['error', 'warn', 'info', 'debug'] as const)
         .default('warn' as const)
+    )
+    .addOption(
+      new Option(
+        '-c, --config <path>',
+        'path to malloy-config.json or directory containing it'
+      )
     );
 
   if (process.env.NODE_ENV === 'test') {
@@ -129,7 +136,7 @@ export function createCLI(): Command {
 
     if (cli.opts().quiet) silenceOut();
 
-    await loadConfig();
+    await loadConfig(cli.opts().config);
     loadConnections(malloyConfig);
   });
 
@@ -184,6 +191,35 @@ export function createCLI(): Command {
     .description(runDescription)
     .addHelpText('after', afterRunHelp)
     .action(runCommand);
+
+  cli
+    .command('build')
+    .argument('[paths...]', 'files or directories to build (default: ".")')
+    .addOption(
+      new Option(
+        '--refresh <tables>',
+        'force rebuild specific tables (conn:name,...)'
+      ).argParser(val => val.split(','))
+    )
+    .addOption(
+      new Option('--dry-run', 'show what would be built without executing')
+    )
+    .summary('build persistent tables from .malloy files')
+    .description(
+      `build persistent tables from .malloy files
+
+Compiles each .malloy file, finds sources annotated with #@ persist, and
+executes them in dependency order. Tables are created using the name specified
+in the persist annotation (e.g. #@ persist name=my_table).
+
+Results are tracked in the manifest so subsequent queries automatically use
+the persisted tables. If a source hasn't changed since the last build, it is
+skipped.
+
+When given a directory, recursively finds all .malloy files. With no arguments,
+builds from the current directory.`
+    )
+    .action(buildCommand);
 
   const connections = cli
     .command('connections')

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,0 +1,14 @@
+/* Copyright Contributors to the Malloy project / SPDX-License-Identifier: MIT */
+
+import {buildFiles} from '../malloy/build';
+
+export async function buildCommand(
+  paths: string[],
+  options: {refresh?: string[]; dryRun?: true}
+): Promise<void> {
+  const refresh = new Set(options.refresh ?? []);
+  await buildFiles(paths, {
+    refresh,
+    dryRun: options.dryRun === true,
+  });
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -102,7 +102,44 @@ function migrateOldConfig(oldConfigPath: string, newConfigPath: string): void {
 let malloyConfig = new MalloyConfig('{"connections":{}}');
 let configFilePath: string;
 
-export async function loadConfig(): Promise<void> {
+/**
+ * Resolve an explicit --config path to a config file path.
+ * Accepts either a direct file path or a directory containing malloy-config.json.
+ */
+function resolveConfigPath(configPath: string): string {
+  const resolved = path.resolve(configPath);
+  try {
+    if (fs.statSync(resolved).isDirectory()) {
+      return path.join(resolved, 'malloy-config.json');
+    }
+  } catch {
+    exitWithError(`Config path not found: ${configPath}`);
+  }
+  return resolved;
+}
+
+export async function loadConfig(explicitPath?: string): Promise<void> {
+  if (explicitPath) {
+    configFilePath = resolveConfigPath(explicitPath);
+    logger.debug(`Loading config from --config: ${configFilePath}`);
+
+    if (!fs.existsSync(configFilePath)) {
+      exitWithError(`Config file not found: ${configFilePath}`);
+    }
+
+    try {
+      const configURL = url.pathToFileURL(configFilePath).toString();
+      malloyConfig = new MalloyConfig(urlReader, configURL);
+      await malloyConfig.load();
+      logger.debug(`Configuration loaded from ${configFilePath}`);
+    } catch (e) {
+      exitWithError(
+        `Error parsing config file at ${configFilePath}: ${errorMessage(e)}`
+      );
+    }
+    return;
+  }
+
   const folder = getDefaultOSConfigFolderPath();
   const malloyDir = path.join(folder, 'malloy');
   configFilePath = path.join(malloyDir, 'malloy-config.json');
@@ -139,6 +176,26 @@ export async function loadConfig(): Promise<void> {
 }
 
 export {malloyConfig};
+
+/**
+ * Derive the manifest file path using the same convention as MalloyConfig:
+ * <configDir>/<manifestPath>/malloy-manifest.json
+ * where manifestPath defaults to "MANIFESTS".
+ *
+ * TODO: Replace this with a `manifestRoot` getter on MalloyConfig in core,
+ * so the path convention lives in one place. MalloyConfig.load() already
+ * computes `new URL(manifestPath, configURL)` — it just needs to store and
+ * expose it. Then this function becomes:
+ *   new URL('malloy-manifest.json', malloyConfig.manifestRoot)
+ */
+export function getManifestFilePath(): string {
+  const manifestDir = malloyConfig.data?.manifestPath ?? 'MANIFESTS';
+  return path.join(
+    path.dirname(configFilePath),
+    manifestDir,
+    'malloy-manifest.json'
+  );
+}
 
 export function saveConfig(): void {
   createDirectoryOrError(

--- a/src/connections/connection_manager.ts
+++ b/src/connections/connection_manager.ts
@@ -27,6 +27,7 @@ import {
   ConnectionConfigEntry,
   LookupConnection,
   MalloyConfig,
+  getRegisteredConnectionTypes,
 } from '@malloydata/malloy';
 import {fileURLToPath} from 'url';
 import path from 'path';
@@ -41,9 +42,38 @@ import '@malloydata/db-snowflake';
 let malloyConfig: MalloyConfig;
 let baseConnections: LookupConnection<Connection>;
 
+/**
+ * Wrap a LookupConnection with a fallback: if the connection name isn't in
+ * the config but matches a registered connection type, create one with
+ * default settings. This makes `duckdb.table(...)` work with no config.
+ */
+function withRegistryFallback(
+  inner: LookupConnection<Connection>
+): LookupConnection<Connection> {
+  const registeredTypes = new Set(getRegisteredConnectionTypes());
+  return {
+    async lookupConnection(connectionName?: string): Promise<Connection> {
+      try {
+        return await inner.lookupConnection(connectionName);
+      } catch (e) {
+        // If the name matches a registered type, create with defaults
+        if (connectionName && registeredTypes.has(connectionName)) {
+          const fallbackConfig = new MalloyConfig(
+            JSON.stringify({
+              connections: {[connectionName]: {is: connectionName}},
+            })
+          );
+          return fallbackConfig.connections.lookupConnection(connectionName);
+        }
+        throw e;
+      }
+    },
+  };
+}
+
 export function loadConnections(config: MalloyConfig): void {
   malloyConfig = config;
-  baseConnections = config.connections;
+  baseConnections = withRegistryFallback(config.connections);
 }
 
 export function getBuildManifest(): BuildManifest {
@@ -87,5 +117,5 @@ export function getConnectionLookup(
         : entry;
   }
   const tempConfig = new MalloyConfig(JSON.stringify({connections: patched}));
-  return tempConfig.connections;
+  return withRegistryFallback(tempConfig.connections);
 }

--- a/src/malloy/build.ts
+++ b/src/malloy/build.ts
@@ -1,0 +1,288 @@
+/* Copyright Contributors to the Malloy project / SPDX-License-Identifier: MIT */
+
+import fs from 'fs';
+import path from 'path';
+import url from 'url';
+import chalk from 'chalk';
+import {Runtime, type Connection, type PersistSource} from '@malloydata/malloy';
+import {getConnectionLookup} from '../connections/connection_manager';
+import {malloyConfig, getManifestFilePath} from '../config';
+import {out} from '../log';
+import {exitWithError, createDirectoryOrError} from '../util';
+import {flattenBuildNodes} from './build_graph';
+
+/**
+ * Create a table from a SELECT statement, using the dialect to quote
+ * the table name properly. Uses DROP+CREATE for cross-dialect safety.
+ *
+ * TODO: Move to core once this stabilizes.
+ */
+async function createTableFromSelect(
+  conn: Connection,
+  source: PersistSource,
+  tableName: string,
+  selectSQL: string
+): Promise<void> {
+  const t = source.dialect.quoteTablePath(tableName);
+  await conn.runSQL(`DROP TABLE IF EXISTS ${t}`);
+  await conn.runSQL(`CREATE TABLE ${t} AS ${selectSQL}`);
+}
+
+export interface BuildOptions {
+  refresh: Set<string>; // "connection:tableName" pairs
+  dryRun: boolean;
+}
+
+/**
+ * Resolve a list of paths into .malloy file paths.
+ * Files are returned as-is (if they end in .malloy).
+ * Directories are recursively scanned for *.malloy files.
+ */
+function resolveMalloyFiles(paths: string[]): string[] {
+  const files: string[] = [];
+
+  for (const p of paths) {
+    const resolved = path.resolve(p);
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(resolved);
+    } catch {
+      exitWithError(`Path not found: ${p}`);
+    }
+
+    if (stat.isDirectory()) {
+      collectMalloyFiles(resolved, files);
+    } else if (resolved.endsWith('.malloy')) {
+      files.push(resolved);
+    } else {
+      exitWithError(`Not a .malloy file: ${p}`);
+    }
+  }
+
+  return files;
+}
+
+function collectMalloyFiles(dir: string, into: string[]): void {
+  for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectMalloyFiles(full, into);
+    } else if (entry.name.endsWith('.malloy')) {
+      into.push(full);
+    }
+  }
+}
+
+export async function buildFiles(
+  paths: string[],
+  options: BuildOptions
+): Promise<void> {
+  const files = resolveMalloyFiles(paths.length > 0 ? paths : ['.']);
+
+  if (files.length === 0) {
+    out('No .malloy files found.');
+    return;
+  }
+
+  const manifest = malloyConfig.manifest;
+  const buildManifest = manifest.buildManifest;
+  const connectionDigests: Record<string, string> = {};
+  let totalBuilt = 0;
+  let totalUpToDate = 0;
+  let totalErrors = 0;
+
+  for (const file of files) {
+    const fileURL = url.pathToFileURL(file);
+    const displayPath = path.relative(process.cwd(), file);
+
+    const runtime = new Runtime({
+      urlReader: {
+        readURL: async (u: URL) =>
+          fs.readFileSync(url.fileURLToPath(u), 'utf8'),
+      },
+      connections: getConnectionLookup(fileURL),
+      buildManifest,
+    });
+
+    let model;
+    try {
+      model = await runtime.loadModel(fileURL).getModel();
+    } catch (e) {
+      out(`\n${chalk.bold(displayPath)}`);
+      out(
+        `  ${chalk.red('✗')} ${chalk.red(
+          `failed to compile: ${e instanceof Error ? e.message : e}`
+        )}`
+      );
+      totalErrors++;
+      continue;
+    }
+
+    let plan;
+    try {
+      plan = model.getBuildPlan();
+    } catch {
+      // No ##! experimental.persistence — skip this file
+      continue;
+    }
+
+    if (plan.graphs.length === 0) {
+      continue;
+    }
+
+    out(`\n${chalk.bold(displayPath)}`);
+
+    for (const graph of plan.graphs) {
+      const connName = graph.connectionName;
+
+      // Get or cache the connection and its digest
+      if (!(connName in connectionDigests)) {
+        const connectionLookup = getConnectionLookup(fileURL);
+        let connection: Connection;
+        try {
+          connection = await connectionLookup.lookupConnection(connName);
+        } catch (e) {
+          out(
+            `  ${chalk.red('✗')} ${chalk.red(
+              `connection "${connName}" not found: ${
+                e instanceof Error ? e.message : e
+              }`
+            )}`
+          );
+          totalErrors++;
+          continue;
+        }
+        connectionDigests[connName] = connection.getDigest();
+      }
+
+      // Flatten into dependency order
+      const allNodes = graph.nodes.flatMap(level =>
+        level.flatMap(node => flattenBuildNodes([node]))
+      );
+      const seenIds = new Set<string>();
+      const uniqueNodes = allNodes.filter(node => {
+        if (seenIds.has(node.sourceID)) return false;
+        seenIds.add(node.sourceID);
+        return true;
+      });
+
+      for (const node of uniqueNodes) {
+        const source = plan.sources[node.sourceID];
+        if (!source) continue;
+
+        const parsed = source.tagParse({prefix: /^#@ /});
+        const tableName = parsed.tag.text('name');
+
+        if (!tableName) {
+          out(
+            `  ${chalk.red('✗')} ${source.name} ${chalk.dim(
+              `(${connName})`
+            )} — ${chalk.red(
+              '#@ persist requires a name (e.g. #@ persist name=my_table)'
+            )}`
+          );
+          totalErrors++;
+          continue;
+        }
+
+        const refreshKey = `${connName}:${tableName}`;
+        const forceRefresh = options.refresh.has(refreshKey);
+
+        const sql = source.getSQL({
+          buildManifest,
+          connectionDigests,
+        });
+        const buildId = source.makeBuildId(connectionDigests[connName], sql);
+
+        // Already built and not in refresh list — skip
+        if (buildManifest[buildId] && !forceRefresh) {
+          manifest.touch(buildId);
+          out(
+            `  ${chalk.green('✓')} ${source.name} ${chalk.dim(
+              `(${connName})`
+            )} — ${chalk.dim('up to date')}`
+          );
+          totalUpToDate++;
+          continue;
+        }
+
+        if (options.dryRun) {
+          const reason = forceRefresh ? 'refresh' : 'new';
+          out(
+            `  ${chalk.yellow('○')} ${source.name} ${chalk.dim(
+              `(${connName})`
+            )} — ${chalk.yellow(`would build (${reason})`)} → ${tableName}`
+          );
+          totalBuilt++;
+          continue;
+        }
+
+        // Build the table
+        const startTime = Date.now();
+        try {
+          const connectionLookup = getConnectionLookup(fileURL);
+          const connection = await connectionLookup.lookupConnection(connName);
+
+          await createTableFromSelect(connection, source, tableName, sql);
+
+          const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+          manifest.update(buildId, {tableName});
+          out(
+            `  ${chalk.green('✓')} ${source.name} ${chalk.dim(
+              `(${connName})`
+            )} — ${chalk.green('built')} ${chalk.dim(
+              `(${elapsed}s)`
+            )} → ${tableName}`
+          );
+          totalBuilt++;
+        } catch (e) {
+          out(
+            `  ${chalk.red('✗')} ${source.name} ${chalk.dim(
+              `(${connName})`
+            )} — ${chalk.red(
+              `build failed: ${e instanceof Error ? e.message : e}`
+            )}`
+          );
+          totalErrors++;
+        }
+      }
+    }
+  }
+
+  // Write manifest
+  if (!options.dryRun && (totalBuilt > 0 || totalUpToDate > 0)) {
+    const manifestPath = getManifestFilePath();
+    createDirectoryOrError(
+      path.dirname(manifestPath),
+      `Could not create manifest directory at ${path.dirname(manifestPath)}`
+    );
+    fs.writeFileSync(
+      manifestPath,
+      JSON.stringify(manifest.activeEntries, null, 2)
+    );
+    out(
+      `\nManifest written: ${chalk.dim(
+        path.relative(process.cwd(), manifestPath)
+      )}`
+    );
+  }
+
+  // Summary
+  const parts: string[] = [];
+  if (totalBuilt > 0)
+    parts.push(
+      chalk.green(`${totalBuilt} ${options.dryRun ? 'to build' : 'built'}`)
+    );
+  if (totalUpToDate > 0) parts.push(chalk.dim(`${totalUpToDate} up to date`));
+  if (totalErrors > 0) parts.push(chalk.red(`${totalErrors} errors`));
+
+  if (parts.length > 0) {
+    out(
+      `\n${options.dryRun ? 'Dry run' : 'Build'} complete: ${parts.join(', ')}`
+    );
+  }
+
+  if (totalErrors > 0 && process.env.NODE_ENV !== 'test') {
+    process.exit(1);
+  }
+}

--- a/src/malloy/build_graph.ts
+++ b/src/malloy/build_graph.ts
@@ -1,0 +1,26 @@
+/* Copyright Contributors to the Malloy project / SPDX-License-Identifier: MIT */
+
+import {type BuildNode} from '@malloydata/malloy';
+
+/**
+ * Flatten a BuildNode tree into topological order (dependencies first).
+ */
+export function flattenBuildNodes(nodes: BuildNode[]): BuildNode[] {
+  const result: BuildNode[] = [];
+  const seen = new Set<string>();
+
+  function visit(node: BuildNode) {
+    if (seen.has(node.sourceID)) return;
+    for (const dep of node.dependsOn) {
+      visit(dep);
+    }
+    seen.add(node.sourceID);
+    result.push(node);
+  }
+
+  for (const node of nodes) {
+    visit(node);
+  }
+
+  return result;
+}

--- a/test/malloy/build.spec.ts
+++ b/test/malloy/build.spec.ts
@@ -1,0 +1,305 @@
+/* Copyright Contributors to the Malloy project / SPDX-License-Identifier: MIT */
+
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import {buildFiles, BuildOptions} from '../../src/malloy/build';
+import {createBasicLogger, silenceOut} from '../../src/log';
+import {loadConnections} from '../../src/connections/connection_manager';
+import {malloyConfig, loadConfig, getManifestFilePath} from '../../src/config';
+
+const TEST_DATA = path.join(__dirname, '..', 'files');
+const AUTO_RECALLS_CSV = path.join(TEST_DATA, 'auto_recalls.csv');
+
+let tempDir: string;
+let modelDir: string;
+let originalXDG: string | undefined;
+
+function writeModel(filename: string, content: string): string {
+  const filePath = path.join(modelDir, filename);
+  fs.writeFileSync(filePath, content);
+  return filePath;
+}
+
+function readManifest(): Record<string, {tableName: string}> {
+  const manifestPath = getManifestFilePath();
+  if (!fs.existsSync(manifestPath)) return {};
+  return JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+}
+
+async function runBuild(
+  paths: string[],
+  options?: Partial<BuildOptions>
+): Promise<void> {
+  await buildFiles(paths, {
+    refresh: new Set(),
+    dryRun: false,
+    ...options,
+  });
+}
+
+// Model with two persist sources
+function modelV1(): string {
+  return `##! experimental.persistence
+
+source: recalls is duckdb.table('${AUTO_RECALLS_CSV}') extend {
+  measure: recall_count is count()
+}
+
+#@ persist name=by_manufacturer
+source: by_manufacturer is recalls -> {
+  group_by: Manufacturer
+  aggregate: recall_count
+}
+
+#@ persist name=by_type
+source: by_type is recalls -> {
+  group_by: \`Recall Type\`
+  aggregate: recall_count
+}
+`;
+}
+
+// Model v2: drop by_type, add by_year
+function modelV2(): string {
+  return `##! experimental.persistence
+
+source: recalls is duckdb.table('${AUTO_RECALLS_CSV}') extend {
+  measure: recall_count is count()
+}
+
+#@ persist name=by_manufacturer
+source: by_manufacturer is recalls -> {
+  group_by: Manufacturer
+  aggregate: recall_count
+}
+
+#@ persist name=by_year
+source: by_year is recalls -> {
+  group_by: recall_year is year(\`Report Received Date\`)
+  aggregate: recall_count
+}
+`;
+}
+
+// Model with persist but no name
+function modelNoName(): string {
+  return `##! experimental.persistence
+
+source: recalls is duckdb.table('${AUTO_RECALLS_CSV}') extend {
+  measure: recall_count is count()
+}
+
+#@ persist
+source: by_manufacturer is recalls -> {
+  group_by: Manufacturer
+  aggregate: recall_count
+}
+`;
+}
+
+// Model with no persist sources
+function modelNoPersist(): string {
+  return `##! experimental.persistence
+
+source: recalls is duckdb.table('${AUTO_RECALLS_CSV}') extend {
+  measure: recall_count is count()
+}
+`;
+}
+
+// Model without experimental.persistence flag
+function modelNoFlag(): string {
+  return `source: recalls is duckdb.table('${AUTO_RECALLS_CSV}') extend {
+  measure: recall_count is count()
+}
+`;
+}
+
+describe('build command', () => {
+  beforeAll(async () => {
+    originalXDG = process.env['XDG_CONFIG_HOME'];
+    createBasicLogger();
+    silenceOut();
+  });
+
+  beforeEach(async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'malloy-cli-build-'));
+    modelDir = path.join(tempDir, 'models');
+    fs.mkdirSync(modelDir, {recursive: true});
+
+    // Set up config with duckdb connection
+    const malloyDir = path.join(tempDir, 'malloy');
+    fs.mkdirSync(malloyDir, {recursive: true});
+    fs.writeFileSync(
+      path.join(malloyDir, 'malloy-config.json'),
+      JSON.stringify({connections: {duckdb: {is: 'duckdb'}}})
+    );
+    process.env['XDG_CONFIG_HOME'] = tempDir;
+
+    await loadConfig();
+    loadConnections(malloyConfig);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, {recursive: true, force: true});
+  });
+
+  afterAll(() => {
+    if (originalXDG !== undefined) {
+      process.env['XDG_CONFIG_HOME'] = originalXDG;
+    } else {
+      delete process.env['XDG_CONFIG_HOME'];
+    }
+  });
+
+  describe('dry run', () => {
+    it('reports sources that would be built', async () => {
+      const file = writeModel('test.malloy', modelV1());
+      await runBuild([file], {dryRun: true});
+
+      // Dry run should not write a manifest
+      const manifest = readManifest();
+      expect(Object.keys(manifest)).toHaveLength(0);
+    });
+
+    it('skips files without experimental.persistence', async () => {
+      const file = writeModel('test.malloy', modelNoFlag());
+      // Should not throw
+      await runBuild([file], {dryRun: true});
+    });
+
+    it('skips files with no persist sources', async () => {
+      const file = writeModel('test.malloy', modelNoPersist());
+      // Should not throw
+      await runBuild([file], {dryRun: true});
+    });
+  });
+
+  describe('building', () => {
+    it('builds two persist sources and writes manifest', async () => {
+      const file = writeModel('test.malloy', modelV1());
+      await runBuild([file]);
+
+      const manifest = readManifest();
+      const names = Object.values(manifest).map(e => e.tableName);
+      expect(names).toContain('by_manufacturer');
+      expect(names).toContain('by_type');
+      expect(Object.keys(manifest)).toHaveLength(2);
+    });
+
+    it('incremental build: unchanged source is skipped, new source is built', async () => {
+      const file = writeModel('test.malloy', modelV1());
+      await runBuild([file]);
+
+      const manifest1 = readManifest();
+      const names1 = Object.values(manifest1).map(e => e.tableName);
+      expect(names1).toContain('by_manufacturer');
+      expect(names1).toContain('by_type');
+
+      // Reload config to get a fresh manifest (simulates a new CLI invocation)
+      await loadConfig();
+      loadConnections(malloyConfig);
+
+      // Change the model: drop by_type, add by_year
+      writeModel('test.malloy', modelV2());
+      await runBuild([file]);
+
+      const manifest2 = readManifest();
+      const names2 = Object.values(manifest2).map(e => e.tableName);
+      expect(names2).toContain('by_manufacturer');
+      expect(names2).toContain('by_year');
+      expect(names2).not.toContain('by_type');
+      expect(Object.keys(manifest2)).toHaveLength(2);
+    });
+
+    it('rebuild same model is all up-to-date', async () => {
+      const file = writeModel('test.malloy', modelV1());
+      await runBuild([file]);
+
+      const manifest1 = readManifest();
+
+      // Build again — nothing should change
+      await runBuild([file]);
+
+      const manifest2 = readManifest();
+      expect(manifest2).toEqual(manifest1);
+    });
+  });
+
+  describe('error handling', () => {
+    it('errors when persist has no name', async () => {
+      const file = writeModel('test.malloy', modelNoName());
+
+      // Should not throw — errors are reported and continued
+      await runBuild([file]);
+
+      // No manifest should be written (no successful builds)
+      const manifest = readManifest();
+      expect(Object.keys(manifest)).toHaveLength(0);
+    });
+  });
+
+  describe('refresh', () => {
+    it('forces rebuild of a specific table', async () => {
+      const file = writeModel('test.malloy', modelV1());
+      await runBuild([file]);
+
+      const manifest1 = readManifest();
+      const buildIds1 = Object.keys(manifest1);
+      expect(buildIds1).toHaveLength(2);
+
+      // Rebuild with refresh on by_manufacturer
+      await runBuild([file], {
+        refresh: new Set(['duckdb:by_manufacturer']),
+      });
+
+      const manifest2 = readManifest();
+      const names2 = Object.values(manifest2).map(e => e.tableName);
+      expect(names2).toContain('by_manufacturer');
+      expect(names2).toContain('by_type');
+      // BuildIDs should be the same (SQL didn't change)
+      expect(Object.keys(manifest2).sort()).toEqual(buildIds1.sort());
+    });
+  });
+
+  describe('directory scanning', () => {
+    it('finds and builds .malloy files in a directory', async () => {
+      writeModel('a.malloy', modelV1());
+      writeModel('b.malloy', modelNoPersist());
+
+      await runBuild([modelDir]);
+
+      const manifest = readManifest();
+      const names = Object.values(manifest).map(e => e.tableName);
+      expect(names).toContain('by_manufacturer');
+      expect(names).toContain('by_type');
+    });
+
+    it('recursively scans subdirectories', async () => {
+      const subDir = path.join(modelDir, 'sub');
+      fs.mkdirSync(subDir, {recursive: true});
+      fs.writeFileSync(path.join(subDir, 'nested.malloy'), modelV1());
+
+      await runBuild([modelDir]);
+
+      const manifest = readManifest();
+      const names = Object.values(manifest).map(e => e.tableName);
+      expect(names).toContain('by_manufacturer');
+    });
+
+    it('defaults to current directory when no paths given', async () => {
+      const origCwd = process.cwd();
+      try {
+        process.chdir(modelDir);
+        writeModel('test.malloy', modelV1());
+        await runBuild([]);
+
+        const manifest = readManifest();
+        expect(Object.keys(manifest).length).toBeGreaterThan(0);
+      } finally {
+        process.chdir(origCwd);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `malloy-cli build [paths...] [--refresh conn:table,...] [--dry-run]` command that compiles `.malloy` files, finds `#@ persist name=<table>` sources, and executes them in dependency order
- Adds global `--config` / `-c` flag so users can point to a project-level `malloy-config.json` (file or directory)
- Adds connection registry fallback so `duckdb.table(...)` works out of the box with no config entry

## Details

**Build command** (`src/commands/build.ts`, `src/malloy/build.ts`, `src/malloy/build_graph.ts`):
- Resolves paths (files or directories, recursive) into `.malloy` files
- Compiles each file, extracts `#@ persist name=<table>` sources via `getBuildPlan()`
- Flattens build graphs into topological (dependency) order
- Content-addressed caching via `makeBuildId()` — unchanged sources are skipped
- `--refresh conn:table` forces rebuild of specific tables
- `--dry-run` shows what would be built without executing
- Errors are reported per-source and don't abort the build
- Manifest is written to `<configDir>/MANIFESTS/malloy-manifest.json`

**Global `--config` flag** (`src/config.ts`, `src/cli.ts`):
- Accepts a file path or directory (looks for `malloy-config.json` inside)
- Enables project-level configs: `malloy-cli --config . build`

**Connection fallback** (`src/connections/connection_manager.ts`):
- `withRegistryFallback()` wraps connection lookups — if a name isn't in config but matches a registered type (e.g. `duckdb`), creates one with defaults
- Matches VS Code extension behavior where default entries exist for each type

## Test plan

- [x] 11 tests in `test/malloy/build.spec.ts` covering:
  - Dry run (reports sources, skips files without persistence flag, skips files with no persist sources)
  - Building (two persist sources, incremental rebuild, idempotent rebuild)
  - Error handling (persist without name)
  - Refresh (force rebuild specific table)
  - Directory scanning (flat, recursive, cwd default)
- [x] ESLint clean
- [x] Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)