### PR TITLE
Add timing, persistence tag fix, notebook skill, and language referen…

### DIFF
--- a/skills/log-analysis-to-notebook.md
+++ b/skills/log-analysis-to-notebook.md
@@ -1,0 +1,98 @@
+---
+description: How to append a Malloy query and its interpretation to a .malloynb notebook file. Follow this when the user says "let's log this", "save this", "add this to the notebook", or similar.
+---
+# Logging an Analysis to a .malloynb Notebook
+
+## When to use this skill
+
+Trigger phrases: "let's log this", "save this to the notebook", "add this to the file", "log that", "add that to the analysis", or any request to persist a query and its results to a notebook.
+
+## Step 1 — Identify the target file
+
+If the user has not specified a `.malloynb` file in this conversation, ask:
+
+> "Which `.malloynb` file should I append this to?"
+
+Do not proceed until you have a file path.
+
+## Step 2 — Read the file to understand its current state
+
+Before appending, read the file so you know:
+- Whether the first cell already contains the experimental flags and import (it should — don't add them again).
+- The existing section structure, so your new section follows the same style.
+
+## Step 3 — Append the new section
+
+**Always append** to the end of the file. Never rewrite existing content.
+
+Each logged analysis consists of these cells in order:
+
+### 1. User question cell
+The user's question, verbatim, as a blockquote. Use a backslash before `>` so it renders as a blockquote, not a Malloy cell marker:
+
+```
+>>>markdown
+\> What are the top directors by total ratings?
+```
+
+### 2. Section header + description cell
+A `##` heading and one sentence describing what the query does:
+
+```
+>>>markdown
+## Top Directors by Total Ratings
+Ranked by sum of vote counts (in thousands) across all their films.
+```
+
+### 3. Query cell
+The Malloy query **without** an import statement (the first cell in the file already imports the model):
+
+```
+>>>malloy
+run: movies -> top_directors
+```
+
+### 4. Interpretation cell
+Bullet-pointed markdown analysis of the results. Lead with the most interesting finding. Use `**bold**` for names and key numbers:
+
+```
+>>>markdown
+- **Christopher Nolan** leads with 18M total votes across 12 films.
+- **Spielberg / Williams** is the most loyal partnership at 85% of films.
+```
+
+## Cell format rules
+
+- Cell delimiters are `>>>malloy` and `>>>markdown` on their own line — no trailing spaces.
+- No blank lines between the delimiter and the cell content.
+- No blank lines between cells (the next `>>>` starts immediately).
+- Do **not** add `>>>malloy` cells for imports or flags — only for executable queries.
+- Lists and bold in markdown cells render correctly; use them freely for analysis.
+
+## Example — what a complete logged section looks like
+
+```
+>>>markdown
+\> Can you find composers that work with the top directors?
+>>>markdown
+## Directors and Their Composer Collaborators
+For each top director, shows the composers they work with most frequently.
+>>>malloy
+run: movies -> {
+  where: job = 'director'
+  group_by: director is name
+  aggregate: total_ratings, title_count
+  nest: composers is {
+    group_by: principals2.people.primaryName
+    where: principals2.category = 'composer'
+    aggregate: title_count, percent_of_titles
+    limit: 5
+  }
+  order_by: total_ratings desc
+  limit: 20
+}
+>>>markdown
+- **Most loyal partnerships** by % of films: Zemeckis/Silvestri (91%), Coen/Burwell (89%), Spielberg/Williams (85%).
+- **Hans Zimmer** is the most in-demand, appearing across six top directors.
+- **Martin Scorsese** is the most eclectic — 31 films, top composer at only 16%.
+```

--- a/skills/malloy-language-reference.md
+++ b/skills/malloy-language-reference.md
@@ -123,6 +123,14 @@ measure:
   pct_delayed is count() { where: dep_delay > 30 } / count()
 ```
 
+**`count(expr)` counts distinct values.** Unlike SQL's `COUNT(DISTINCT expr)`, Malloy uses `count(expr)` for distinct counting. The `count(distinct expr)` form is a deprecated syntax that will produce an error. Use `count()` for total row count, `count(field)` for distinct values of that field:
+
+```malloy
+aggregate:
+  total_rows is count()               -- all rows
+  unique_carriers is count(carrier)   -- distinct carriers
+```
+
 Measures can be filtered inline with `{ where: ... }`, which is how you build things like "percent of flights delayed" without subqueries.
 
 ### Views
@@ -296,6 +304,20 @@ run: airports -> {
 ```
 
 `all(expr)` removes all grouping. `all(expr, dim1, dim2)` keeps only the specified grouping dimensions. `exclude(expr, dim)` removes the specified dimension from grouping.
+
+**Important:** `all(expr, dim)` takes the **local alias name** as defined in the query's `group_by:`, not a dotted path. If you want to partition by a joined field, alias it first:
+
+```malloy
+-- WRONG: all(count(), director.primaryName)  -- dot paths don't work here
+-- RIGHT:
+run: movies -> {
+  group_by: director is director.primaryName   -- alias it
+  aggregate:
+    movies is count()
+    director_total is all(count(), director)   -- reference the alias
+    pct is count() / all(count(), director)
+}
+```
 
 ## Expressions
 

--- a/src/mcp/loader.ts
+++ b/src/mcp/loader.ts
@@ -132,6 +132,23 @@ export function errorProblem(e: unknown, uri?: string): Problem {
 }
 
 /**
+ * When a manifest is configured, inline sources need ##! experimental.persistence
+ * in their root compilation unit or the Runtime silently ignores the manifest
+ * (it only checks the root file's tags, not imported files).
+ */
+function withPersistenceTag(source: string): string {
+  if (!malloyConfig.manifestURL) return source;
+  const lines = source.split('\n');
+  const tagIdx = lines.findIndex(l => /^##!/.test(l));
+  if (tagIdx !== -1) {
+    if (lines[tagIdx].includes('experimental.persistence')) return source;
+    lines[tagIdx] += ' experimental.persistence';
+    return lines.join('\n');
+  }
+  return '##! experimental.persistence\n' + source;
+}
+
+/**
  * Load and compile a Malloy model from either a file URI or an inline source
  * string. Returns the loaded Model plus the root URL it was loaded from (so
  * callers can distinguish "local to this file" from "imported").
@@ -153,10 +170,13 @@ export async function loadModel(input: SourceInput): Promise<LoadResult> {
     };
   }
 
+  const resolvedSource =
+    input.source !== undefined ? withPersistenceTag(input.source) : undefined;
+
   const rootUrl = input.uri
     ? normalizeUri(input.uri)
     : inlineVirtualUrl(input.baseUri);
-  const {urlReader, readSource} = makeReader(rootUrl, input.source);
+  const {urlReader, readSource} = makeReader(rootUrl, resolvedSource);
   const runtime = new Runtime({config: malloyConfig, urlReader});
 
   try {

--- a/src/mcp/run.ts
+++ b/src/mcp/run.ts
@@ -25,6 +25,8 @@ export interface RunResult {
   rowCount?: number;
   truncated?: boolean;
   rows?: unknown[];
+  compileTimeMS?: number;
+  totalTimeMS?: number;
   problems: Problem[];
 }
 
@@ -113,8 +115,11 @@ export async function run(
     }
 
     const rowLimit = selector.rowLimit ?? DEFAULT_ROW_LIMIT;
+    const t0 = Date.now();
     const sql = (await query.getSQL()).trim();
+    const t1 = Date.now();
     const results = await query.run({rowLimit});
+    const t2 = Date.now();
     const json = results.toJSON();
     const rows = (json.queryResult?.result ?? []) as unknown[];
     const truncated = rows.length === rowLimit;
@@ -124,6 +129,8 @@ export async function run(
       rowCount: rows.length,
       truncated,
       rows,
+      compileTimeMS: t1 - t0,
+      totalTimeMS: t2 - t0,
       problems: loadRes.problems,
     };
   } catch (e) {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -67,7 +67,31 @@ joins actually exist and how they relate. Always prefer \`compile_file\`
 (or \`compile\` for an inline draft) over reading a .malloy file with a
 generic text tool.
 
-Typical workflows:
+## Always show the Malloy source and timing
+
+After every \`run\`, \`run_file\`, \`compile\`, or \`compile_file\` call — whether
+it succeeded or failed — show the user:
+
+1. **The Malloy query** that was submitted (the inline \`source\` string, or the
+   file URI plus the name/index selected). Show it even when there are errors.
+2. **Execution time**: on a successful run, display \`totalTimeMS\` as
+   "X ms total (Y ms compile)". On failure, omit timing.
+
+Example success display:
+\`\`\`
+Malloy:
+  run: flights -> { aggregate: flight_count is count() }
+Result: 42 rows in 312 ms total (18 ms compile)
+\`\`\`
+
+Example failure display:
+\`\`\`
+Malloy:
+  run: flights -> { aggregate: fligth_count is count() }
+Error: field-not-found — 'fligth_count' does not exist on 'flights'
+\`\`\`
+
+## Typical workflows
 
 - "What's in this .malloy file?" / "What can I ask of this model?"
     → call \`compile_file\` on the file. Inspect \`model.sources\`, \`.queries\`,
@@ -91,6 +115,14 @@ pick expressions, time ranges, tags/annotations), call
 \`language_help(topic)\` before guessing. Call it again after any compile
 error whose fix is not obvious from the message — problem entries carry
 a \`help_topic\` field when there's a natural match.
+
+## Logging analyses to a notebook
+
+When the user says "let's log this", "save this", "add this to the
+notebook", or any similar phrase — load and follow the
+\`log-analysis-to-notebook\` skill (available as an MCP prompt/resource).
+It describes the .malloynb cell format, how to ask for the target file
+if one hasn't been specified, and what to append.
 `.trim();
 
 export interface McpServerOptions {


### PR DESCRIPTION
…ce clarifications

- MCP run/run_file now return compileTimeMS and totalTimeMS; server prompt instructs Claude to display them after every run or compile call.
- loader: inject ##! experimental.persistence into inline sources when a manifest is configured (Runtime silently ignores manifests otherwise).
- Add log-analysis-to-notebook skill and wire it into the server prompt so Claude knows to use it when the user says "save this" or "log this".
- Language reference: clarify count(expr) for distinct counting (not the deprecated count(distinct expr) form) and that all(expr, dim) takes the local alias name, not a dotted path.