### PR TITLE
fix(build): verify manifest tables before treating sources as up-to-date

### DIFF
--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -26,11 +26,42 @@ import {defaultBuildDirectory, doBuild} from './build';
 import * as pkg from 'pkg';
 import path from 'path';
 import * as fs from 'fs';
+import {execSync} from 'child_process';
 import {Command} from '@commander-js/extra-typings';
 import {
   getTargetDuckDBPackageMap,
   resolveDuckDBNative,
 } from './utils/fetch-duckdb';
+
+/**
+ * Build metadata for binary builds: tells the user which commit a
+ * locally-built binary corresponds to. Returns a semver build-metadata
+ * suffix (`+<date>.<sha>[.dirty]`); leaves npm semver ordering alone
+ * because build metadata is ignored for ordering. Returns '' if we can't
+ * read git (e.g. building from a tarball outside a repo).
+ */
+function getBuildMetadataSuffix(): string {
+  try {
+    const sha = execSync('git rev-parse --short=7 HEAD', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim();
+    const dirty = execSync('git status --porcelain', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim()
+      ? '.dirty'
+      : '';
+    const now = new Date();
+    const date = `${now.getFullYear()}.${String(now.getMonth() + 1).padStart(
+      2,
+      '0'
+    )}.${String(now.getDate()).padStart(2, '0')}`;
+    return `+${date}.${sha}${dirty}`;
+  } catch {
+    return '';
+  }
+}
 
 const nodeTarget = 'node18';
 const outputFolder = 'pkg/';
@@ -40,7 +71,8 @@ async function packageCLI(
   architecture: string,
   sign = true,
   skipPackageStep = false,
-  version = 'dev'
+  version = 'dev',
+  filenameVersion = version
 ) {
   let target = `${platform}-${architecture}`;
 
@@ -83,7 +115,7 @@ async function packageCLI(
     '--target',
     `${nodeTarget}-${target}`,
     '--output',
-    path.join(outputFolder, `/malloy-cli-${target}-${version}`),
+    path.join(outputFolder, `/malloy-cli-${target}-${filenameVersion}`),
     '--compress',
     'gzip',
   ]);
@@ -161,6 +193,8 @@ interface PackageTarget {
   fs.mkdirSync(outputFolder, {recursive: true});
 
   const versionBits = getVersionBits();
+  const filenameVersion = versionBits.join('.');
+  const version = filenameVersion + getBuildMetadataSuffix();
 
   for (const target of targets) {
     console.log(
@@ -171,7 +205,8 @@ interface PackageTarget {
       target.architecture,
       options.sign,
       options.skipPackage,
-      versionBits.join('.')
+      version,
+      filenameVersion
     );
   }
 })()

--- a/src/malloy/build.ts
+++ b/src/malloy/build.ts
@@ -31,6 +31,30 @@ async function createTableFromSelect(
   await conn.runSQL(`CREATE TABLE ${t} AS ${selectSQL}`);
 }
 
+/**
+ * Check that a manifest table is still usable by compiling a tiny Malloy
+ * source against it. This goes through the same schema-fetch path query
+ * compilation will, so success here means the manifest entry can actually
+ * back queries — not just "exists in the catalog." Used to validate a
+ * proposed "up to date" skip before trusting the manifest. Failure (table
+ * dropped, file moved, connection unreachable, etc.) returns false and the
+ * source falls through to rebuild.
+ */
+async function manifestTableStillUsable(
+  runtime: Runtime,
+  connName: string,
+  tableName: string
+): Promise<boolean> {
+  const escaped = tableName.replace(/'/g, "''");
+  const probe = `source: __doesItBlend is ${connName}.table('${escaped}')`;
+  try {
+    await runtime.loadModel(probe).getModel();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export interface BuildOptions {
   refresh: Set<string>; // "connection:tableName" pairs
   dryRun: boolean;
@@ -245,16 +269,37 @@ export async function buildFiles(
           source.getSQL()
         );
 
-        // Already built and not in refresh list — skip
-        if (buildManifest.entries[buildId] && !forceRefresh) {
-          manifest.touch(buildId);
-          out(
-            `  ${chalk.green('✓')} ${source.name} ${chalk.dim(
-              `(${connName})`
-            )} — ${chalk.dim('up to date')}`
+        // Already built and not in refresh list — skip, but only if the
+        // table the manifest points to is still usable. The manifest can
+        // outlive its database (file deleted, project copied without the
+        // data dir, restored from a backup that didn't include it, etc.);
+        // trusting it blindly produced "build complete" with no data on
+        // disk. We probe via a Malloy compile against the same connection
+        // so this matches what query compilation will see.
+        const existingEntry = buildManifest.entries[buildId];
+        if (existingEntry && !forceRefresh) {
+          const usable = await manifestTableStillUsable(
+            runtime,
+            connName,
+            existingEntry.tableName
           );
-          totalUpToDate++;
-          continue;
+          if (usable) {
+            manifest.touch(buildId);
+            out(
+              `  ${chalk.green('✓')} ${source.name} ${chalk.dim(
+                `(${connName})`
+              )} — ${chalk.dim('up to date')}`
+            );
+            totalUpToDate++;
+            continue;
+          }
+          out(
+            `  ${chalk.yellow('…')} ${source.name} ${chalk.dim(
+              `(${connName})`
+            )} — ${chalk.yellow(
+              `manifest entry stale (${existingEntry.tableName} missing), rebuilding`
+            )}`
+          );
         }
 
         if (options.dryRun) {

--- a/test/malloy/build.spec.ts
+++ b/test/malloy/build.spec.ts
@@ -6,7 +6,7 @@ import os from 'os';
 import {buildFiles, BuildOptions} from '../../src/malloy/build';
 import {createBasicLogger, silenceOut} from '../../src/log';
 import '../../src/connections/connection_manager';
-import {loadConfig} from '../../src/config';
+import {loadConfig, malloyConfig} from '../../src/config';
 
 const TEST_DATA = path.join(__dirname, '..', 'files');
 const AUTO_RECALLS_CSV = path.join(TEST_DATA, 'auto_recalls.csv');
@@ -218,6 +218,65 @@ describe('build command', () => {
       expect(names2).toContain('by_year');
       expect(names2).not.toContain('by_type');
       expect(Object.keys(manifest2.entries)).toHaveLength(2);
+    });
+
+    it('rebuilds when the database file is missing even if manifest says up-to-date', async () => {
+      // Repro of the user-reported "build succeeds with checkmarks but no
+      // data" bug: manifest entries persist across CLI invocations, but if
+      // the database file has gone missing (rm, restored backup without
+      // data/, machine move, etc.) the cli currently trusts the manifest,
+      // skips DROP/CREATE, and exits successfully — leaving an empty
+      // freshly-initialized DuckDB file (12288 bytes) with no tables.
+      //
+      // Use a file-backed duckdb connection (the default config in this
+      // suite is :memory:, which can't reproduce the bug because the
+      // tables vanish with the connection anyway).
+      const dbPath = path.join(tempDir, 'test.duckdb');
+      const malloyDir = path.join(tempDir, 'malloy');
+      fs.writeFileSync(
+        path.join(malloyDir, 'malloy-config.json'),
+        JSON.stringify({
+          connections: {duckdb: {is: 'duckdb', databasePath: dbPath}},
+        })
+      );
+      await loadConfig();
+
+      const file = writeModel('test.malloy', modelV1());
+      await runBuild([file]);
+
+      // First build: tables should be in the file.
+      async function tablesInDb(): Promise<string[]> {
+        const conn = await malloyConfig.connections.lookupConnection('duckdb');
+        const result = await conn.runSQL(
+          'SELECT table_name FROM duckdb_tables() ORDER BY table_name'
+        );
+        return (result.rows as Array<{table_name: string}>).map(
+          r => r.table_name
+        );
+      }
+      expect(await tablesInDb()).toEqual(
+        expect.arrayContaining(['by_manufacturer', 'by_type'])
+      );
+
+      // Simulate the user scenario: drop the connection so the file lock
+      // is released, then delete the database file. Manifest stays.
+      await malloyConfig.releaseConnections();
+      fs.unlinkSync(dbPath);
+      const walPath = `${dbPath}.wal`;
+      if (fs.existsSync(walPath)) fs.unlinkSync(walPath);
+
+      // Reload config so the next build starts from a clean connection cache.
+      await loadConfig();
+      expect(fs.existsSync(dbPath)).toBe(false);
+
+      // Re-run the build. The cli currently prints "up to date" for every
+      // source and writes nothing to the database — that's the bug. After
+      // the fix, the build should detect the missing tables and rebuild.
+      await runBuild([file]);
+
+      expect(await tablesInDb()).toEqual(
+        expect.arrayContaining(['by_manufacturer', 'by_type'])
+      );
     });
 
     it('rebuild same model is all up-to-date', async () => {

--- a/test/malloy/build.spec.ts
+++ b/test/malloy/build.spec.ts
@@ -250,9 +250,7 @@ describe('build command', () => {
         const result = await conn.runSQL(
           'SELECT table_name FROM duckdb_tables() ORDER BY table_name'
         );
-        return (result.rows as Array<{table_name: string}>).map(
-          r => r.table_name
-        );
+        return result.rows.map(row => String(row['table_name']));
       }
       expect(await tablesInDb()).toEqual(
         expect.arrayContaining(['by_manufacturer', 'by_type'])
@@ -260,7 +258,7 @@ describe('build command', () => {
 
       // Simulate the user scenario: drop the connection so the file lock
       // is released, then delete the database file. Manifest stays.
-      await malloyConfig.releaseConnections();
+      await malloyConfig.shutdown('close');
       fs.unlinkSync(dbPath);
       const walPath = `${dbPath}.wal`;
       if (fs.existsSync(walPath)) fs.unlinkSync(walPath);


### PR DESCRIPTION
## Summary

- `malloy-cli build` now compiles a tiny inline Malloy source against each manifest entry it's about to skip, so the "up to date" branch only wins when the table is actually reachable. Stale entries fall through to rebuild with `… name (conn) — manifest entry stale (<table> missing), rebuilding`.
- Standalone binary `--version` now embeds `+<date>.<sha>[.dirty]` build metadata so a locally-built `malloy-cli --version` tells you which commit you're running. Published npm package version is unchanged — `npm install -g @malloydata/cli` still prints a clean semver.

## Background

@loydtabb reported running `malloy-cli build transform.malloy` against `~/dev/malloy-imdb` with no `data/imdb.duckdb` present. Build prints ✓ "up to date" for all three sources, exits 0, and leaves a 12288-byte empty DuckDB file with no tables.

The mechanism: `lookupConnection` constructs the DuckDBConnection, whose `init()` calls `DuckDBInstance.create(path)` which **creates the file if missing**. The build loop computes each source's `buildId`, finds it in `manifest.entries` (left over from a previous successful build), takes the "already built" branch — `manifest.touch(buildId)` and `continue` — without doing any DROP/CREATE. cli is happy, database is empty.

The fix uses the malloy compile path (`source: __doesItBlend is <conn>.table('<name>')`) rather than a connection-level "does this table exist" probe — that way a successful check means malloy can actually use the table at query time, not just "exists in some catalog." Same path queries take, same per-table schema cache, no new connection-level method.

Trigger surface this fixes: `rm data/imdb.duckdb`, restoring a backup that didn't include `data/`, copying the project to a new machine, file truncated/corrupted by another tool — all produced silent "build complete with checkmarks but no data" before this change.

## Workaround until this lands

Delete the `MANIFESTS/` directory in the project root and rerun the build. The cli will see no manifest, take the "new" branch for every source, and rebuild everything from scratch.
