### PR TITLE
mcp: surface and supply givens in describe/run tools

### DIFF
--- a/skills/malloy-language-reference.md
+++ b/skills/malloy-language-reference.md
@@ -11,12 +11,13 @@ A core design principle is that **most queries are themselves designing a new se
 
 ## Documents and Statements
 
-A Malloy file (`.malloy`) is a sequence of statements, optionally separated by semicolons. There are four statement types:
+A Malloy file (`.malloy`) is a sequence of statements, optionally separated by semicolons. There are five statement types:
 
 - **`import`** — import sources and queries from another `.malloy` file
 - **`source:`** — define a named, reusable data source with its schema and extensions
 - **`query:`** — define a named query (source + view) for reuse
 - **`run:`** — execute a query (the "do it now" statement)
+- **`given:`** — declare model-level parameters supplied at run time (experimental, see Givens)
 
 ```malloy
 import "shared_model.malloy"
@@ -419,7 +420,7 @@ Not all annotations are tags. An annotation is just text. Tags are annotations t
 The character(s) immediately after `#` route the annotation to different consumers:
 
 - `# ` (hash-space) — renderer tags, parsed by the Malloy VS Code extension for visualization
-- `##!` — compiler directives (e.g., `##! experimental.parameters`)
+- `##!` — compiler directives (e.g., `##! experimental.parameters`, `##! experimental.givens`)
 - `#"` — reserved for documentation strings
 - `#(appName)` — application-specific tags (e.g., `#(docs) hidden`)
 
@@ -442,6 +443,142 @@ tName.sub.path=value          -- deep path assignment
 ```
 
 Values can be unquoted identifiers, quoted strings, numbers, or typed values prefixed with `@` (`@true`, `@false`, `@2024-01-15`).
+
+## Givens (Model-Level Parameters)
+
+**Status: experimental, gated by `##! experimental.givens`.** Naming is provisional.
+
+Givens are values supplied at run time that the model can reference in any expression. The motivating use case is row-level access control — a model written once with `where: x.tenant_id = $TENANT` and the tenant supplied per API call — but they also fit configuration values, session context, and any "one compiled model, many invocations with varying context" pattern.
+
+Givens are model-wide: a single namespace, one value per name per compilation. They are *complementary to* source/query parameters (`source: foo(x :: string) is ...`), not a replacement. Use a parameter when you want two differently-bound copies of the same source side-by-side in one model; use a given when you want one value visible everywhere in the compilation.
+
+### Declaration
+
+The `given:` top-level statement introduces givens, with a name, a type, and an optional default:
+
+```malloy
+given:
+  TENANT :: string
+  MAX_ROWS :: number is 1000
+  CUTOFF_DATE :: date is @2024-01-01
+```
+
+Type can be any Malloy atomic type or compound type, including `filter<T>`:
+
+```malloy
+given:
+  ROLE :: string
+  ALLOWED_ROLES :: string[]
+  SESSION :: { user_id :: string, tenant :: string }
+  TENANT_FILTER :: filter<string>
+```
+
+Defaults are expressions over constants and other givens. Annotations attach to given declarations the same way they attach to sources or measures.
+
+### Reference: the `$` sigil
+
+Inside any expression, a given is referenced with a leading `$`:
+
+```malloy
+source: orders_for_user is orders extend {
+  where: orders.tenant_id = $TENANT
+}
+
+query: recent_orders is orders_for_user -> {
+  where: order_date >= $CUTOFF_DATE
+  limit: $MAX_ROWS
+}
+```
+
+`$` appears *only* at expression references. The other three sites where a given's name appears — declaration, import, and supply (caller side) — use the bare name, because syntactic position already disambiguates. Givens share the top-level declaration namespace with sources/queries/views, so `source: x is ...` plus `given: x :: string` is a name-conflict error.
+
+### Imports
+
+Givens behave like every other top-level named thing under import:
+
+- **Bare import** (`import "b.malloy"`) brings B's full export surface in, including all of B's givens, under their original names.
+- **Selective import** (`import { source1 } from "b.malloy"`) brings in only what's listed. To surface a given to your callers, list it: `import { source1, MAX_ROWS } from "b.malloy"`.
+- **Rename** uses the existing `LOCAL is REMOTE` form: `import { CAP is MAX_ROWS } from "b.malloy"`.
+
+Surfacing controls *who can supply a value*, not whether internal references work. An imported source can reference a given the importer didn't surface; the reference still resolves internally, and at run time the unsurfaced given relies on its declaration-site default.
+
+A common project convention is a shared `tenant_givens.malloy` (declaring `$TENANT`, `$USER_ROLE`, etc.) that every root file bare-imports on line 1, so the project's given contract is visible at the top of any model.
+
+### Satisfiability
+
+A query referencing `$X` is satisfiable if either `$X` is in the model's namespace (so a caller can supply a value) or `$X` has a default at its declaration site. Otherwise the query is unsatisfiable and errors. Latent definitions (views, dimensions, measures) that reference `$X` are fine if no query actually invokes them — satisfiability is a property of running queries.
+
+### Supplying values
+
+Values can be supplied at two layers, which compose (per-query overrides per-runtime):
+
+**Per-runtime** — bound to a `Runtime`, applied as defaults to every query through it. Two paths:
+
+1. **`givensPath` in `malloy-config.json`** points at a JSON file of `name → value`:
+   ```jsonc
+   { "givensPath": "./local-givens.json" }
+   // or env-var indirection (resolved at config load):
+   { "givensPath": { "env": "GAME_STORE_GIVENS" } }
+   ```
+   The values file is a flat JSON map, keys are caller-facing surface names:
+   ```jsonc
+   { "TENANT": "acme", "USER_ROLE": "admin", "CUTOFF_DATE": "2024-01-01" }
+   ```
+
+2. **Direct on the Runtime constructor** (for per-request multi-tenant servers, tests, scripts):
+   ```typescript
+   const runtime = new Runtime({
+     config,
+     givens: { TENANT: claims.tenant_id, USER_ROLE: claims.role },
+     urlReader,
+   });
+   ```
+   Constructor values *merge over* the file at `givensPath` per-key.
+
+**Per-query** — supplied on a single `.run({ givens: ... })` call:
+```typescript
+await query.run({ givens: { STATE_FILTER: "CA", LIMIT_OVERRIDE: 50 } })
+```
+Available on every compile-or-run entry point (`runtime.loadQuery(...).run(options)`, `preparedQuery.getPreparedResult(options)`, `preparedQuery.getSQL(options)`).
+
+The resolved per-runtime values are exposed on `runtime.givens` (read-only) for diagnostics.
+
+### Finalized givens (security primitive)
+
+A multi-tenant deployment usually wants `TENANT`/`USER_ROLE`/`REGION` to be runtime-bound and **un-overridable per-query** — otherwise a downstream endpoint that accidentally accepts user-controlled query params and plumbs them into `.run({ givens: ... })` becomes a tenant-leak vulnerability.
+
+`finalizeGivens` in the config locks names at the API surface:
+
+```jsonc
+{
+  "givensPath": { "env": "GAME_STORE_GIVENS" },
+  "finalizeGivens": ["TENANT", "USER_ROLE", "REGION"]
+}
+```
+
+Finalize doesn't change *what* a given resolves to — only *who* can supply it. A `.run({ givens: { TENANT: ... } })` for a finalized name throws at API entry (named, not silently dropped). Finalized givens are filtered out of `Model.givens` and `PreparedQuery.givens` so introspection-driven UIs don't render editors for locked names.
+
+### JS shapes for supplied values
+
+Both the JSON values file and per-query `givens` maps accept the same per-type shapes:
+
+| Malloy type | JS |
+|---|---|
+| `string` | string |
+| `number` | `number`, `bigint`, or string (precision escape hatch) |
+| `boolean` | boolean |
+| `date` | ISO date string `"2024-01-15"` |
+| `timestamp` (naive) | ISO string without offset — *not* a JS `Date` |
+| `timestamptz` | JS `Date` or ISO string with offset (string preferred — makes TZ choice visible) |
+| `T[]` | JS array |
+| `{ name :: T, ... }` | JS object |
+| `filter<T>` | JS string (Malloy filter expression source) |
+
+Naive timestamp givens reject `Date` because `Date` represents a UTC instant, not a wall-clock value, and `new Date("2001-01-01T00:00:00")` silently picks up the system's local TZ. Type mismatches throw at the boundary with a path that points at the offending location (e.g., `givens.SESSION.user_id: expected string, got number`). `null` is legal for any given type.
+
+### Introspection
+
+`Model.givens` and `PreparedQuery.givens` expose, to the host, the supplyable givens — for whole-model parameter editors and per-query "run this" forms respectively. Each entry carries name, type, default expression (or undefined if the caller must supply), location, and access to declaration-site annotations via `tagParse`/`getTaglines`.
 
 ## How a Malloy Query Becomes SQL
 

--- a/skills/writing-malloy-with-mcp.md
+++ b/skills/writing-malloy-with-mcp.md
@@ -11,8 +11,8 @@ This CLI exposes five tools. "Compile" means parse + typecheck + build the model
 |-----------------|----------------------------------------|--------------------------------------------------------------------------------|
 | `compile_file`  | `{ uri, expand? }`                     | Fetch+compile a .malloy file; returns structured model with problems[].        |
 | `compile`       | `{ source, base_uri?, expand? }`       | Same, on an inline source string.                                              |
-| `run_file`      | `{ uri, name?, index? }`               | Execute one run: from a file. `name` wins over `index`; else last run:.        |
-| `run`           | `{ source, base_uri? }`                | Execute the final run: from an inline source.                                  |
+| `run_file`      | `{ uri, name?, index?, givens? }`      | Execute one run: from a file. `name` wins over `index`; else last run:.        |
+| `run`           | `{ source, base_uri?, givens? }`       | Execute the final run: from an inline source.                                  |
 | `list_runs`     | `{ uri }`                              | Cheap discovery: runnable run: + named queries, no model serialization.        |
 
 Every tool returns a uniform `problems[]` with `{ severity, message, code, uri?, line, column, endLine?, endColumn? }`. Compile errors, import-resolution errors, and runtime SQL errors all use this shape.
@@ -78,6 +78,21 @@ Feed that whole thing to `compile`. Imports resolve against `base_uri` if suppli
 - **Aggregate locality** — `sum(joined.x)` across a join boundary requires explicit locality: `source.sum(joined.x)` or `joined.x.sum()`.
 - **Mixed reduction/projection** — a single stage uses either `group_by:`/`aggregate:` OR `select:`, not both.
 - **Calculation in source** — `calculate:` (window functions) only lives in queries, never in source definitions.
+
+## Running a query that declares givens
+
+Givens are model-level parameters (`given: TENANT :: string`, referenced as `$TENANT`). When a model declares them:
+
+1. `compile_file` (or `list_runs`) reports `model.givens[]` (full list with type/default) and per-run/per-query `givens: ["NAME", ...]` arrays — the names that run needs supplied.
+2. Pass values to `run`/`run_file` via the `givens` map, keyed by surface name (no `$`):
+
+```jsonc
+{ "uri": "file:///.../model.malloy", "givens": { "TENANT": "acme", "MAX_ROWS": 100 } }
+```
+
+3. **For per-type JS shapes** (date as ISO string, naive timestamp as ISO without offset, record as JS object, `filter<T>` as a Malloy filter source string, etc.) call `language_help("givens")` — the "JS shapes for supplied values" subsection is the canonical reference. Don't guess; the compiler validates and rejects bad shapes with a path to the offending field.
+
+A given with a default is optional in the `givens` map. A given without a default must be supplied or the run fails with a missing-given error.
 
 ## Before writing non-trivial Malloy
 

--- a/src/mcp/compile.ts
+++ b/src/mcp/compile.ts
@@ -75,6 +75,11 @@ interface NamedQueryInfo {
   annotations?: string[];
   location?: Loc;
   body?: string;
+  /**
+   * Surface names of givens this query references (transitive). Look up
+   * details in `model.givens[]`. Only emitted when non-empty.
+   */
+  givens?: string[];
 }
 
 interface RunInfo {
@@ -84,11 +89,36 @@ interface RunInfo {
   location?: Loc;
   sql?: string;
   error?: string;
+  /**
+   * Surface names of givens this run references (transitive). Look up
+   * details in `model.givens[]`. Only emitted when non-empty.
+   */
+  givens?: string[];
+}
+
+interface GivenInfo {
+  name: string;
+  /**
+   * Malloy-syntax rendering of the declared type. Atomic types render to
+   * their type name (`"string"`, `"number"`, `"date"`, ...); arrays as
+   * `"T[]"`; records collapse to `"record"` / `"record[]"`; filter
+   * expressions render as `"filter<T>"`. For full compound-type detail
+   * see `body`.
+   */
+  type: string;
+  /** True if the declaration provides a default — caller may omit a value. */
+  hasDefault: boolean;
+  /** Verbatim source slice of the declaration when locally defined. */
+  body?: string;
+  annotations?: string[];
+  location?: Loc;
 }
 
 interface ModelDescription {
   rootUri: string;
   annotations?: string[];
+  /** Givens declared in (or imported into) this model. Only when non-empty. */
+  givens?: GivenInfo[];
   sources: SourceInfo[];
   queries: NamedQueryInfo[];
   runs: RunInfo[];
@@ -330,6 +360,74 @@ function describeExplore(e: Explore, ctx: DescribeContext): SourceInfo {
   return out;
 }
 
+/**
+ * Structural subset of the malloy `GivenTypeDef` union (`AtomicTypeDef |
+ * FilterExpressionParamTypeDef`). Neither type is re-exported from the
+ * package root, so we describe the fields we actually read.
+ */
+type GivenTypeShape = {
+  type: string;
+  filterType?: string;
+  elementTypeDef?: GivenTypeShape;
+};
+
+function renderGivenType(t: GivenTypeShape): string {
+  if (t.type === 'filter expression') {
+    return t.filterType ? `filter<${t.filterType}>` : 'filter';
+  }
+  if (t.type === 'array') {
+    const elem = t.elementTypeDef;
+    if (!elem) return 'array';
+    if (elem.type === 'record_element') return 'record[]';
+    return `${renderGivenType(elem)}[]`;
+  }
+  return t.type;
+}
+
+/**
+ * Structural subset of the malloy foundation `Given` wrapper class. The
+ * class itself isn't re-exported from the package root, so we accept any
+ * value that supplies the fields we read.
+ */
+type GivenLike = {
+  readonly type: GivenTypeShape;
+  readonly default: unknown;
+  readonly location: MalloyLocation | undefined;
+  getTaglines(prefix?: RegExp): string[];
+};
+
+function describeGiven(
+  g: GivenLike,
+  surfaceName: string,
+  ctx: DescribeContext
+): GivenInfo {
+  const info: GivenInfo = {
+    name: surfaceName,
+    type: renderGivenType(g.type),
+    hasDefault: g.default !== undefined,
+  };
+  const annotations = g.getTaglines?.() ?? [];
+  if (annotations.length > 0) info.annotations = annotations;
+  const loc = g.location;
+  if (loc && isLocal(loc, ctx.rootUri)) {
+    const l = toLoc(loc);
+    if (l) info.location = l;
+    const body = sliceSource(ctx.readSource(loc.url), loc);
+    if (body) info.body = body;
+  }
+  return info;
+}
+
+function readQueryGivens(
+  getPq: () => {givens: ReadonlyMap<string, unknown>}
+): string[] {
+  try {
+    return [...getPq().givens.keys()];
+  } catch {
+    return [];
+  }
+}
+
 function annotationNotes(
   ann: {notes?: {text: string}[]; blockNotes?: {text: string}[]} | undefined
 ): string[] {
@@ -362,13 +460,18 @@ async function describeModel(
   for (const nq of model.namedQueries) {
     const loc = nq.location as MalloyLocation | undefined;
     if (!isLocal(loc, rootUri)) continue;
-    const info: NamedQueryInfo = {name: nq.as ?? nq.name ?? ''};
+    const queryName = nq.as ?? nq.name ?? '';
+    const info: NamedQueryInfo = {name: queryName};
     const notes = annotationNotes(nq.annotation);
     if (notes.length > 0) info.annotations = notes;
     const l = toLoc(loc);
     if (l) info.location = l;
     const body = sliceSource(readSource(rootUri), loc);
     if (body) info.body = body;
+    const givenNames = readQueryGivens(() =>
+      model.getPreparedQueryByName(queryName)
+    );
+    if (givenNames.length > 0) info.givens = givenNames;
     queries.push(info);
   }
 
@@ -382,20 +485,33 @@ async function describeModel(
     if (notes.length > 0) info.annotations = notes;
     const l = toLoc(q.location as MalloyLocation | undefined);
     if (l) info.location = l;
-    if (opts.emitRunSql) {
-      try {
-        const pq = model.getPreparedQueryByIndex(idx);
+    try {
+      const pq = model.getPreparedQueryByIndex(idx);
+      const givenNames = [...pq.givens.keys()];
+      if (givenNames.length > 0) info.givens = givenNames;
+      if (opts.emitRunSql) {
         info.sql = pq.preparedResult.sql.trim();
-      } catch (e) {
+      }
+    } catch (e) {
+      // Pre-givens behavior: errors here were only surfaced when the caller
+      // asked for SQL. Preserve that — silently omit givens if reading them
+      // fails outside an SQL request.
+      if (opts.emitRunSql) {
         info.error = e instanceof Error ? e.message : String(e);
       }
     }
     runs.push(info);
   }
 
+  const givensList: GivenInfo[] = [];
+  for (const [surfaceName, g] of model.givens) {
+    givensList.push(describeGiven(g, surfaceName, ctx));
+  }
+
   const modelAnnotations = model.getTaglines?.() ?? [];
   const out: ModelDescription = {rootUri, sources, queries, runs};
   if (modelAnnotations.length > 0) out.annotations = modelAnnotations;
+  if (givensList.length > 0) out.givens = givensList;
   return out;
 }
 
@@ -442,8 +558,14 @@ export async function listRuns(input: SourceInput): Promise<{
     name?: string;
     location?: Loc;
     annotations?: string[];
+    givens?: string[];
   }>;
-  queries: Array<{name: string; location?: Loc; annotations?: string[]}>;
+  queries: Array<{
+    name: string;
+    location?: Loc;
+    annotations?: string[];
+    givens?: string[];
+  }>;
   problems: Problem[];
 }> {
   const res = await loadModel(input);
@@ -458,12 +580,17 @@ export async function listRuns(input: SourceInput): Promise<{
       name?: string;
       location?: Loc;
       annotations?: string[];
+      givens?: string[];
     } = {index: idx};
     if (q.name) entry.name = q.name;
     const l = toLoc(q.location as MalloyLocation | undefined);
     if (l) entry.location = l;
     const notes = annotationNotes(q.annotation);
     if (notes.length > 0) entry.annotations = notes;
+    const givenNames = readQueryGivens(() =>
+      model.getPreparedQueryByIndex(idx)
+    );
+    if (givenNames.length > 0) entry.givens = givenNames;
     return entry;
   });
   const queries = model.namedQueries
@@ -471,13 +598,21 @@ export async function listRuns(input: SourceInput): Promise<{
       isLocal(nq.location as MalloyLocation | undefined, rootUrl.href)
     )
     .map(nq => {
-      const entry: {name: string; location?: Loc; annotations?: string[]} = {
-        name: nq.as ?? nq.name ?? '',
-      };
+      const queryName = nq.as ?? nq.name ?? '';
+      const entry: {
+        name: string;
+        location?: Loc;
+        annotations?: string[];
+        givens?: string[];
+      } = {name: queryName};
       const l = toLoc(nq.location as MalloyLocation | undefined);
       if (l) entry.location = l;
       const notes = annotationNotes(nq.annotation);
       if (notes.length > 0) entry.annotations = notes;
+      const givenNames = readQueryGivens(() =>
+        model.getPreparedQueryByName(queryName)
+      );
+      if (givenNames.length > 0) entry.givens = givenNames;
       return entry;
     });
   return {

--- a/src/mcp/run.ts
+++ b/src/mcp/run.ts
@@ -1,6 +1,6 @@
 /* Copyright Contributors to the Malloy project / SPDX-License-Identifier: MIT */
 
-import {MalloyError} from '@malloydata/malloy';
+import {MalloyError, GivenValue} from '@malloydata/malloy';
 import {
   SourceInput,
   Problem,
@@ -18,6 +18,13 @@ export interface RunSelector {
   index?: number;
   /** Maximum number of rows to return. Defaults to DEFAULT_ROW_LIMIT. */
   rowLimit?: number;
+  /**
+   * Per-query given values, keyed by caller-facing surface name. Override
+   * runtime-level defaults for this call only. The set of given names a
+   * query needs is reported by `compile_file` / `list_runs` on the run or
+   * query entry.
+   */
+  givens?: Record<string, GivenValue>;
 }
 
 export interface RunResult {
@@ -116,10 +123,13 @@ export async function run(
     }
 
     const rowLimit = selector.rowLimit ?? DEFAULT_ROW_LIMIT;
+    const compileOpts = selector.givens ? {givens: selector.givens} : undefined;
     const t0 = Date.now();
-    const sql = (await query.getSQL()).trim();
+    const sql = (await query.getSQL(compileOpts)).trim();
     const t1 = Date.now();
-    const results = await withDuckdbLockRetry(() => query.run({rowLimit}));
+    const results = await withDuckdbLockRetry(() =>
+      query.run({rowLimit, ...compileOpts})
+    );
     const t2 = Date.now();
     const json = results.toJSON();
     const rows = json.queryResult.result;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -2,6 +2,7 @@
 
 import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
 import {StdioServerTransport} from '@modelcontextprotocol/sdk/server/stdio.js';
+import {GivenValue} from '@malloydata/malloy';
 import {z} from 'zod';
 import {compile, listRuns} from './compile';
 import {run} from './run';
@@ -42,6 +43,21 @@ const uriSchema = z
 
 const sourceSchema = z.string().describe('Malloy source code.');
 
+const givensSchema = z
+  .record(z.string(), z.unknown())
+  .optional()
+  .describe(
+    'Per-query given values, keyed by caller-facing surface name (no `$` ' +
+      "prefix). Override the runtime's defaults for this call only. Use " +
+      '`compile_file` (or `list_runs`) to see which givens a run/query ' +
+      'needs — each entry carries a `givens` array of the names it ' +
+      'references. For per-type JS shapes (date as ISO string, naive ' +
+      'timestamp as ISO without offset, record as JS object, ' +
+      'filter<T> as Malloy filter source string, ...) call ' +
+      '`language_help("givens")` — the "JS shapes for supplied values" ' +
+      'subsection is the canonical reference.'
+  );
+
 const baseUriSchema = z
   .string()
   .optional()
@@ -50,6 +66,18 @@ const baseUriSchema = z
       'Typically the file:// URI of the file the snippet will live next to. ' +
       'If omitted, imports must be absolute.'
   );
+
+/**
+ * Single place we acknowledge the wire→JS type gap: MCP carries JSON, and
+ * JSON values are a runtime subset of malloy's `GivenValue` (which also
+ * admits `Date` and `bigint` for native JS callers). Malloy validates
+ * per-type when consuming.
+ */
+function asGivens(
+  v: Record<string, unknown> | undefined
+): Record<string, GivenValue> | undefined {
+  return v as Record<string, GivenValue> | undefined;
+}
 
 function toContent(result: object) {
   // MCP spec requires `structuredContent` to be a JSON object (zod
@@ -162,7 +190,10 @@ export async function runMcpServer(): Promise<void> {
         'Compile a .malloy file at the given URI and return the full ' +
         'structured model: sources (with dimensions, measures, views, ' +
         'joins), named queries, top-level run: statements with their SQL, ' +
-        'and annotations. This is the primary way to understand what is in ' +
+        'givens (model-level parameters declared with `given:`), and ' +
+        'annotations. Each query/run carries the transitive set of given ' +
+        'names it references — the values a caller must supply to execute it. ' +
+        'This is the primary way to understand what is in ' +
         'a .malloy file — what data sources it defines, what can be queried, ' +
         'what the schema looks like — whether you are about to edit it, ' +
         'answer a question with it, or just explore it. Reading the file as ' +
@@ -226,7 +257,10 @@ export async function runMcpServer(): Promise<void> {
         'Execute one run: or named query from a .malloy file against the ' +
         "user's configured connections. Selection: `name` wins if provided, " +
         'else `index` (0-based into run: statements), else the final run:. ' +
-        'Returns the generated SQL and rows (default 10000, set row_limit to override).',
+        'Returns the generated SQL and rows (default 10000, set row_limit ' +
+        'to override). If the run/query references givens (model-level ' +
+        'parameters — see `compile_file` output), supply per-call values ' +
+        'via the `givens` map.',
       inputSchema: {
         uri: uriSchema,
         name: z
@@ -245,10 +279,14 @@ export async function runMcpServer(): Promise<void> {
           .int()
           .optional()
           .describe('Maximum number of rows to return. Defaults to 10000.'),
+        givens: givensSchema,
       },
     },
-    async ({uri, name, index, row_limit}) => {
-      const result = await run({uri}, {name, index, rowLimit: row_limit});
+    async ({uri, name, index, row_limit, givens}) => {
+      const result = await run(
+        {uri},
+        {name, index, rowLimit: row_limit, givens: asGivens(givens)}
+      );
       await idleConnections();
       return toContent(result);
     }
@@ -264,7 +302,9 @@ export async function runMcpServer(): Promise<void> {
       description:
         'Compile an inline Malloy source and execute its final run: ' +
         "statement against the user's configured connections. Returns the " +
-        'generated SQL and rows (default 10000, set row_limit to override). Use this after compile is ' +
+        'generated SQL and rows (default 10000, set row_limit to override). ' +
+        'If the source declares givens (model-level parameters), supply ' +
+        'per-call values via the `givens` map. Use this after compile is ' +
         'clean to see the answer.',
       inputSchema: {
         source: sourceSchema,
@@ -274,12 +314,13 @@ export async function runMcpServer(): Promise<void> {
           .int()
           .optional()
           .describe('Maximum number of rows to return. Defaults to 10000.'),
+        givens: givensSchema,
       },
     },
-    async ({source, base_uri, row_limit}) => {
+    async ({source, base_uri, row_limit, givens}) => {
       const result = await run(
         {source, baseUri: base_uri},
-        {rowLimit: row_limit}
+        {rowLimit: row_limit, givens: asGivens(givens)}
       );
       await idleConnections();
       return toContent(result);
@@ -360,9 +401,12 @@ export async function runMcpServer(): Promise<void> {
       description:
         'Lightweight discovery: return the runnable run: statements (with ' +
         'optional names and indexes) and named `query:` definitions in a ' +
-        'file, without serializing the full model. Use this when you only ' +
-        'need to know what can be executed; if you need to understand the ' +
-        'schema (sources, measures, views, joins), use compile_file instead.',
+        'file, without serializing the full model. Each entry also carries ' +
+        'the transitive set of given names it references — the parameters ' +
+        'a caller must supply to execute it. Use this when you only need ' +
+        'to know what can be executed; if you need the full givens schema ' +
+        '(types, defaults, annotations) or any source/field detail, use ' +
+        'compile_file instead.',
       inputSchema: {uri: uriSchema},
     },
     async ({uri}) => {


### PR DESCRIPTION
## Summary

End-to-end MCP-server support for Malloy's experimental `given:` model-level parameters so an agent can both **discover** what a model needs and **supply** values when running it.

- **`compile_file` / `list_runs`** now report `model.givens[]` (name, rendered type, `hasDefault`, verbatim declaration `body`, annotations) plus per-run and per-named-query `givens: [...]` arrays — the transitive set of given names each one references, sourced from `PreparedQuery.givens`.
- **`run` / `run_file`** accept a `givens` map (surface name → value) that overrides runtime defaults for that call. Threaded into both `query.getSQL` and `query.run`. Type-mismatch and missing-given errors flow through the existing `MalloyError → Problem` mapping with paths into the offending location.
- **Skills**: `malloy-language-reference` gains a "Givens (Model-Level Parameters)" section (declaration, `$` sigil, imports/surfacing, satisfiability, supply layers, `finalizeGivens`, JS-shape table, introspection, contrast with source parameters). `writing-malloy-with-mcp` documents the run-with-givens workflow and points at `language_help("givens")` for per-type JS shapes.

Reuses the existing structural-type pattern in `compile.ts` for fields the malloy package doesn't re-export from its root (`Given`, `GivenTypeDef`); the one cast across the wire→JS gap (`Record<string, unknown>` → `Record<string, GivenValue>`) is centralized in a single commented `asGivens()` adapter.


🤖 Generated with [Claude Code](https://claude.com/claude-code)