### PR TITLE
cli: --givens flag on run and compile

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,7 +52,18 @@ also compiled.
 
 When compiling a query using a Malloy file....`;
 
+const givensHelp = `
+Supplying givens (model parameters declared with \`given:\`) — three modes:
+  --givens '{"TENANT":"acme","MAX_ROWS":100}'   inline JSON object
+  --givens @givens.json                         read from a file
+  --givens @-                                   read from stdin
+
+Values layer over any \`givensPath\` in the project's malloy-config.json
+(per-key, --givens wins). Names finalized at the runtime layer
+(\`finalizeGivens\` in config) cannot be supplied this way.`;
+
 const afterCompileHelp = `
+${givensHelp}
 
 Examples:
 
@@ -60,7 +71,10 @@ Compile a MalloySQL file and output SQL:
 compile file.malloysql -o malloy compiled-sql
 
 Compile a MalloySQL file and output each statement as SQL using JSON:
-compile file.malloysql -f json`;
+compile file.malloysql -f json
+
+Compile with a given supplied inline:
+compile file.malloy --givens '{"TENANT":"acme"}'`;
 
 const runDescription = `execute a Malloy file (.malloy or .malloysql)
 
@@ -73,6 +87,7 @@ When executing a Malloy file, include either a name to a query (--name), the ind
 query (--index), or a new query as the final argument.`;
 
 const afterRunHelp = `
+${givensHelp}
 
 Examples:
 
@@ -86,7 +101,12 @@ Run the second MalloySQL statement in a file and output the results:
 run file.malloysql --index 2 -o results
 
 Run a Malloy query using file.malloy and output the results as JSON:
-run file.malloy "source->{ aggregate: my_field }"`;
+run file.malloy "source->{ aggregate: my_field }"
+
+Run with givens supplied inline, from a file, or from stdin:
+run file.malloy --givens '{"TENANT":"acme","MAX_ROWS":100}'
+run file.malloy --givens @givens.json
+fetch-context | run file.malloy --givens @-`;
 
 export function createCLI(): Command {
   const cli = new Command()
@@ -176,6 +196,12 @@ export function createCLI(): Command {
       ).conflicts('index')
     )
     .addOption(new Option('-j, --json', 'output json'))
+    .addOption(
+      new Option(
+        '-g, --givens <spec>',
+        'given values: inline JSON, @file.json, or @- for stdin'
+      )
+    )
     .summary('compile a Malloy file (.malloy or .malloysql)')
     .description(compileDescription)
     .addHelpText('after', afterCompileHelp)
@@ -207,6 +233,12 @@ export function createCLI(): Command {
         '--row-limit <number>',
         'maximum number of rows to return'
       ).argParser(parseFloat)
+    )
+    .addOption(
+      new Option(
+        '-g, --givens <spec>',
+        'given values: inline JSON, @file.json, or @- for stdin'
+      )
     )
     .summary('execute a Malloy file (.malloy or .malloysql)')
     .description(runDescription)

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -22,6 +22,8 @@
  */
 
 import {runOrCompile} from '../malloy/util';
+import {parseGivensSpec} from '../malloy/givens';
+import {exitWithError} from '../util';
 
 export async function compileCommand(
   source: string,
@@ -30,7 +32,16 @@ export async function compileCommand(
     index?: number | undefined;
     name?: string | undefined;
     json?: true | undefined;
+    givens?: string | undefined;
   }
 ): Promise<void> {
-  await runOrCompile(source, query, options, true);
+  let givens;
+  if (options.givens !== undefined) {
+    try {
+      givens = parseGivensSpec(options.givens);
+    } catch (e) {
+      exitWithError(e instanceof Error ? e.message : String(e));
+    }
+  }
+  await runOrCompile(source, query, {...options, givens}, true);
 }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -22,6 +22,8 @@
  */
 
 import {runOrCompile} from '../malloy/util';
+import {parseGivensSpec} from '../malloy/givens';
+import {exitWithError} from '../util';
 
 export async function runCommand(
   source: string,
@@ -31,7 +33,16 @@ export async function runCommand(
     name?: string | undefined;
     json?: true | undefined;
     rowLimit?: number | undefined;
+    givens?: string | undefined;
   }
 ): Promise<void> {
-  await runOrCompile(source, query, options);
+  let givens;
+  if (options.givens !== undefined) {
+    try {
+      givens = parseGivensSpec(options.givens);
+    } catch (e) {
+      exitWithError(e instanceof Error ? e.message : String(e));
+    }
+  }
+  await runOrCompile(source, query, {...options, givens});
 }

--- a/src/malloy/givens.ts
+++ b/src/malloy/givens.ts
@@ -1,0 +1,66 @@
+/* Copyright Contributors to the Malloy project / SPDX-License-Identifier: MIT */
+
+import fs from 'fs';
+import {GivenValue} from '@malloydata/malloy';
+
+/**
+ * Parse the value of `--givens <spec>` into a name→value map suitable for
+ * `query.getSQL({givens})` and `query.run({givens})`.
+ *
+ * Three input modes, curl-style:
+ *   - `@-`          read JSON from stdin
+ *   - `@path`       read JSON from a file
+ *   - anything else parse as inline JSON
+ *
+ * The JSON must be an object (`{NAME: value, ...}`). Per-value type validity
+ * against the model's declared givens is enforced by malloy core at bind
+ * time; this parser only checks the outer shape.
+ */
+export function parseGivensSpec(
+  spec: string,
+  opts: {readStdin?: () => string} = {}
+): Record<string, GivenValue> {
+  let source: string;
+  let origin: string;
+  if (spec === '@-') {
+    const reader = opts.readStdin ?? (() => fs.readFileSync(0, 'utf-8'));
+    source = reader();
+    origin = '<stdin>';
+  } else if (spec.startsWith('@')) {
+    const path = spec.slice(1);
+    try {
+      source = fs.readFileSync(path, 'utf-8');
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      throw new Error(`--givens: cannot read ${path}: ${msg}`);
+    }
+    origin = path;
+  } else {
+    source = spec;
+    origin = '<inline>';
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`--givens (${origin}): invalid JSON: ${msg}`);
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(
+      `--givens (${origin}): expected a JSON object of {NAME: value, ...}, got ${describeJsonShape(
+        parsed
+      )}`
+    );
+  }
+
+  return parsed as Record<string, GivenValue>;
+}
+
+function describeJsonShape(v: unknown): string {
+  if (v === null) return 'null';
+  if (Array.isArray(v)) return 'array';
+  return typeof v;
+}

--- a/src/malloy/malloy.ts
+++ b/src/malloy/malloy.ts
@@ -86,7 +86,8 @@ export async function runMalloy(
         }
       } else query = modelMaterializer.loadFinalQuery();
 
-      const sql = await query.getSQL();
+      const givensOpt = options.givens ? {givens: options.givens} : {};
+      const sql = await query.getSQL(givensOpt);
       json['sql'] = sql.trim();
 
       if (options.compileOnly) {
@@ -97,7 +98,7 @@ export async function runMalloy(
       }
 
       const rowLimit = options.rowLimit ?? DEFAULT_ROW_LIMIT;
-      const results = await query.run({rowLimit});
+      const results = await query.run({rowLimit, ...givensOpt});
       const rows = results.toJSON().queryResult.result;
       if (rows.length === rowLimit) {
         resultsLog.result(`WARNING: Results truncated to ${rowLimit} results.`);

--- a/src/malloy/malloySQL.ts
+++ b/src/malloy/malloySQL.ts
@@ -100,6 +100,7 @@ export async function runMalloySQL(
       );
     }
     const statements = parse.statements;
+    const givensOpt = options.givens ? {givens: options.givens} : {};
 
     if (statementIndex !== null) {
       resultsLog.task(
@@ -168,7 +169,7 @@ export async function runMalloySQL(
           try {
             const finalQuery = modelMaterializer.loadQuery(fileURL);
             const finalQuerySQL = await withDuckdbLockRetry(() =>
-              finalQuery.getSQL()
+              finalQuery.getSQL(givensOpt)
             );
 
             if (compileOnly) {
@@ -179,7 +180,7 @@ export async function runMalloySQL(
 
               const rowLimit = options.rowLimit ?? DEFAULT_ROW_LIMIT;
               const results = await withDuckdbLockRetry(() =>
-                finalQuery.run({rowLimit})
+                finalQuery.run({rowLimit, ...givensOpt})
               );
               const rows = results.toJSON().queryResult.result;
               if (rows.length === rowLimit) {
@@ -211,7 +212,7 @@ export async function runMalloySQL(
               `\nrun: ${malloyQuery.query}`
             );
             const generatedSQL = await withDuckdbLockRetry(() =>
-              runnable.getSQL()
+              runnable.getSQL(givensOpt)
             );
 
             compiledStatement = compiledStatement.replace(

--- a/src/malloy/util.ts
+++ b/src/malloy/util.ts
@@ -21,6 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import {GivenValue} from '@malloydata/malloy';
 import {transports, format, createLogger as createWinstonLogger} from 'winston';
 import {TransformFunction} from 'logform';
 import {out as cliLogger, silent} from '../log';
@@ -77,6 +78,7 @@ export interface RunOrCompileOptions {
   queryOptions?: QueryOptions;
   json: boolean;
   rowLimit?: number;
+  givens?: Record<string, GivenValue>;
 }
 
 export async function runOrCompile(
@@ -87,6 +89,7 @@ export async function runOrCompile(
     name?: string | undefined;
     json?: true | undefined;
     rowLimit?: number | undefined;
+    givens?: Record<string, GivenValue> | undefined;
   },
   compileOnly = false
 ): Promise<void> {
@@ -141,6 +144,7 @@ export async function runOrCompile(
     json: options.json === true,
     queryOptions,
     rowLimit: options.rowLimit ?? DEFAULT_ROW_LIMIT,
+    givens: options.givens,
   };
 
   if (extension === '.malloysql') {

--- a/test/commands/run.spec.ts
+++ b/test/commands/run.spec.ts
@@ -85,6 +85,46 @@ describe('commands', () => {
       );
     });
 
+    it('accepts --givens with inline JSON on a malloy file that uses one', async () => {
+      await runWith(
+        'run',
+        path.resolve(path.join(__dirname, '..', 'files', 'givens_test.malloy')),
+        '--givens',
+        '{"TARGET":2}'
+      );
+    });
+
+    it('accepts --givens @file', async () => {
+      const givensFile = path.join(tempDir, 'givens.json');
+      fs.writeFileSync(givensFile, '{"TARGET":3}');
+      await runWith(
+        'run',
+        path.resolve(path.join(__dirname, '..', 'files', 'givens_test.malloy')),
+        '--givens',
+        `@${givensFile}`
+      );
+    });
+
+    it('rejects malformed --givens JSON', async () => {
+      expect.assertions(1);
+      return await runWith(
+        'run',
+        path.resolve(path.join(__dirname, '..', 'files', 'givens_test.malloy')),
+        '--givens',
+        '{not json'
+      ).catch(e => expect(errorMessage(e)).toMatch(/invalid JSON/));
+    });
+
+    it('rejects non-object --givens JSON', async () => {
+      expect.assertions(1);
+      return await runWith(
+        'run',
+        path.resolve(path.join(__dirname, '..', 'files', 'givens_test.malloy')),
+        '--givens',
+        '[1,2]'
+      ).catch(e => expect(errorMessage(e)).toMatch(/expected a JSON object/));
+    });
+
     it('fails if index and query name are both passed', async () => {
       expect.assertions(1);
       return await runWith(

--- a/test/files/givens_sql.malloy
+++ b/test/files/givens_sql.malloy
@@ -1,0 +1,5 @@
+##! experimental.givens
+given:
+  favorite :: number is 1
+
+run: duckdb.sql("SELECT 1 as one") -> { select: current_favorite is $favorite }

--- a/test/files/givens_test.malloy
+++ b/test/files/givens_test.malloy
@@ -1,0 +1,7 @@
+##! experimental.givens
+given:
+  TARGET :: number is 0
+
+source: nums is duckdb.sql("SELECT 1 as v UNION SELECT 2 UNION SELECT 3")
+
+run: nums -> { select: v; where: v = $TARGET }

--- a/test/malloy/givens.spec.ts
+++ b/test/malloy/givens.spec.ts
@@ -1,0 +1,96 @@
+/* Copyright Contributors to the Malloy project / SPDX-License-Identifier: MIT */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {parseGivensSpec} from '../../src/malloy/givens';
+
+describe('parseGivensSpec', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'malloy-cli-givens-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, {recursive: true, force: true});
+  });
+
+  describe('inline JSON', () => {
+    it('parses an object', () => {
+      expect(parseGivensSpec('{"TENANT":"acme","MAX":100}')).toEqual({
+        TENANT: 'acme',
+        MAX: 100,
+      });
+    });
+
+    it('handles nested compound values', () => {
+      expect(parseGivensSpec('{"CAPS":["a","b"],"S":{"id":1}}')).toEqual({
+        CAPS: ['a', 'b'],
+        S: {id: 1},
+      });
+    });
+
+    it('accepts an empty object', () => {
+      expect(parseGivensSpec('{}')).toEqual({});
+    });
+
+    it('rejects invalid JSON', () => {
+      expect(() => parseGivensSpec('{not json')).toThrow(/invalid JSON/);
+    });
+
+    it('rejects a top-level array', () => {
+      expect(() => parseGivensSpec('[1,2]')).toThrow(
+        /expected a JSON object .* got array/
+      );
+    });
+
+    it('rejects a top-level scalar', () => {
+      expect(() => parseGivensSpec('"hi"')).toThrow(
+        /expected a JSON object .* got string/
+      );
+    });
+
+    it('rejects top-level null', () => {
+      expect(() => parseGivensSpec('null')).toThrow(
+        /expected a JSON object .* got null/
+      );
+    });
+  });
+
+  describe('@file', () => {
+    it('reads JSON from a file', () => {
+      const p = path.join(tempDir, 'g.json');
+      fs.writeFileSync(p, '{"X":1}');
+      expect(parseGivensSpec(`@${p}`)).toEqual({X: 1});
+    });
+
+    it('reports the file path on missing file', () => {
+      const p = path.join(tempDir, 'nope.json');
+      expect(() => parseGivensSpec(`@${p}`)).toThrow(
+        new RegExp(`cannot read ${p.replace(/\//g, '\\/')}`)
+      );
+    });
+
+    it('reports the file path on invalid JSON', () => {
+      const p = path.join(tempDir, 'bad.json');
+      fs.writeFileSync(p, '{nope');
+      expect(() => parseGivensSpec(`@${p}`)).toThrow(
+        new RegExp(`${path.basename(p)}.*invalid JSON`)
+      );
+    });
+  });
+
+  describe('@- (stdin)', () => {
+    it('reads from the injected stdin reader', () => {
+      const got = parseGivensSpec('@-', {readStdin: () => '{"FROM":"stdin"}'});
+      expect(got).toEqual({FROM: 'stdin'});
+    });
+
+    it('reports <stdin> on invalid JSON from stdin', () => {
+      expect(() => parseGivensSpec('@-', {readStdin: () => 'garbage'})).toThrow(
+        /<stdin>.*invalid JSON/
+      );
+    });
+  });
+});

--- a/test/malloy/givens.spec.ts
+++ b/test/malloy/givens.spec.ts
@@ -67,17 +67,22 @@ describe('parseGivensSpec', () => {
 
     it('reports the file path on missing file', () => {
       const p = path.join(tempDir, 'nope.json');
-      expect(() => parseGivensSpec(`@${p}`)).toThrow(
-        new RegExp(`cannot read ${p.replace(/\//g, '\\/')}`)
-      );
+      expect(() => parseGivensSpec(`@${p}`)).toThrow(`cannot read ${p}`);
     });
 
     it('reports the file path on invalid JSON', () => {
       const p = path.join(tempDir, 'bad.json');
       fs.writeFileSync(p, '{nope');
-      expect(() => parseGivensSpec(`@${p}`)).toThrow(
-        new RegExp(`${path.basename(p)}.*invalid JSON`)
-      );
+      const thrown = (() => {
+        try {
+          parseGivensSpec(`@${p}`);
+          return undefined;
+        } catch (e) {
+          return e instanceof Error ? e.message : String(e);
+        }
+      })();
+      expect(thrown).toContain(p);
+      expect(thrown).toContain('invalid JSON');
     });
   });
 

--- a/test/malloy/malloy.spec.ts
+++ b/test/malloy/malloy.spec.ts
@@ -27,6 +27,7 @@ import os from 'os';
 import {loadConfig} from '../../src/config';
 import '../../src/connections/connection_manager';
 import {createBasicLogger, silenceOut} from '../../src/log';
+import {runMalloy} from '../../src/malloy/malloy';
 
 const configFixture = path.resolve(
   path.join(__dirname, '..', 'files', 'merged_config.json')
@@ -60,5 +61,27 @@ describe('Malloy', () => {
 
   it('runs Malloy, outputs results', () => {
     // TODO
+  });
+
+  describe('givens', () => {
+    const fixture = path.resolve(
+      path.join(__dirname, '..', 'files', 'givens_sql.malloy')
+    );
+
+    it('default value reaches compiled SQL when no givens supplied', async () => {
+      const out = await runMalloy(fixture, {compileOnly: true, json: true});
+      const {sql} = JSON.parse(out as string);
+      expect(sql).toMatch(/1\s+as\s+"current_favorite"/i);
+    });
+
+    it('--givens override reaches compiled SQL', async () => {
+      const out = await runMalloy(fixture, {
+        compileOnly: true,
+        json: true,
+        givens: {favorite: 137},
+      });
+      const {sql} = JSON.parse(out as string);
+      expect(sql).toMatch(/137\s+as\s+"current_favorite"/i);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Brings per-call givens parity to the CLI — the MCP server inside the CLI already accepts a `givens` map; this exposes the same primitive to direct CLI / agent-execution callers.

One flag, three curl-style input modes:

```
--givens '{"TENANT":"acme","MAX_ROWS":100}'   # inline JSON
--givens @givens.json                         # file
--givens @-                                   # stdin
```

Each mode fits a natural caller:
- Subprocess / agent harness: inline JSON, no shell, no quoting (`JSON.stringify` straight into argv).
- Human at a terminal: `@file`, no inline quoting.
- Pipe composition (openclaude-style): `producer | malloy-cli run foo --givens @-`.

The `@`-prefix file form deliberately *doesn't* claim the bare stdin channel — it stays free for a future `malloy-cli run -` that reads malloy source from stdin.
