### PR TITLE
mcp: restricted server mode for publishing curated models

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -334,9 +334,25 @@ exits non-zero.`
 Exposes Malloy authoring capabilities (compile_malloy tool, bundled
 language-reference prompts) as a Model Context Protocol server. Intended to
 be spawned by an MCP client (Claude Code, Claude Desktop, etc.) — not run
-interactively. Reads JSON-RPC frames on stdin and writes replies on stdout.`
+interactively. Reads JSON-RPC frames on stdin and writes replies on stdout.
+
+With --restricted, the server exposes only the curated models under the
+-p DIR project dir (those carrying a ##|(mcp-description) marker). Clients
+select a model by handle and submit query text that is compiled in restricted
+mode — no import, no raw file/table access, no SQL escape hatches.`
     )
-    .action(mcpCommand);
+    .option(
+      '--restricted',
+      'serve only curated models under -p DIR; clients submit restricted ' +
+        'query text against a selected model (no import / raw URIs / SQL ' +
+        'escapes). Requires -p DIR.'
+    )
+    .action(opts =>
+      mcpCommand({
+        restricted: !!opts.restricted,
+        projectDir: cli.opts().projectDir,
+      })
+    );
 
   cli
     .command('third-party')

--- a/src/commands/fmt.ts
+++ b/src/commands/fmt.ts
@@ -1,10 +1,9 @@
 /* Copyright Contributors to the Malloy project / SPDX-License-Identifier: MIT */
 
 import fs from 'fs';
-import path from 'path';
 import {prettifyMalloy, PrettifyError} from '../malloy/prettify';
 import {out} from '../log';
-import {exitWithError} from '../util';
+import {exitWithError, findMalloyFiles, isMalloyFile} from '../util';
 
 export interface FmtOptions {
   write?: true;
@@ -89,7 +88,7 @@ function collectFiles(paths: string[]): string[] {
     }
     const stat = fs.statSync(p);
     if (stat.isDirectory()) {
-      walk(p, acc);
+      acc.push(...findMalloyFiles(p));
     } else if (isMalloyFile(p)) {
       acc.push(p);
     } else {
@@ -97,22 +96,6 @@ function collectFiles(paths: string[]): string[] {
     }
   }
   return acc;
-}
-
-function walk(dir: string, acc: string[]): void {
-  for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
-    if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      walk(full, acc);
-    } else if (entry.isFile() && isMalloyFile(full)) {
-      acc.push(full);
-    }
-  }
-}
-
-function isMalloyFile(p: string): boolean {
-  return path.extname(p).toLowerCase() === '.malloy';
 }
 
 function reportErrors(label: string, errors: PrettifyError[]): void {

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -1,12 +1,16 @@
 /* Copyright Contributors to the Malloy project / SPDX-License-Identifier: MIT */
 
-import {runMcpServer} from '../mcp/server';
+import {runMcpServer, McpServerOptions} from '../mcp/server';
 
 /**
  * Run the CLI as a stdio-based MCP server. stdout is reserved for JSON-RPC
  * frames; the preAction hook in cli.ts has already routed logging to stderr
  * and silenced `out()` for this subcommand.
+ *
+ * With `restricted`, the server publishes only the curated models under the
+ * `-p DIR` project dir and accepts restricted query text against them — no
+ * arbitrary file access or SQL escape hatches.
  */
-export async function mcpCommand(): Promise<void> {
-  await runMcpServer();
+export async function mcpCommand(opts: McpServerOptions = {}): Promise<void> {
+  await runMcpServer(opts);
 }

--- a/src/mcp/restricted.ts
+++ b/src/mcp/restricted.ts
@@ -1,0 +1,286 @@
+/* Copyright Contributors to the Malloy project / SPDX-License-Identifier: MIT */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import {MalloyError, GivenValue} from '@malloydata/malloy';
+import {Problem, loadModel, mapProblems, errorProblem} from './loader';
+import {compile, CompileResult, CompileOptions} from './compile';
+import {RunResult, RunSelector} from './run';
+import {DEFAULT_ROW_LIMIT} from '../malloy/util';
+import {withDuckdbLockRetry} from '../util';
+
+/**
+ * Restricted-mode MCP surface. The trust boundary: an untrusted agent picks
+ * one of the operator's *published* models by handle and submits restricted
+ * query text that compiles against it. The agent never supplies a file URI,
+ * an `import`, or any of the SQL escape hatches — malloy core's
+ * `loadRestrictedQuery` rejects those at translate time.
+ *
+ * A model is published only if it carries the opt-in marker annotation
+ * `##|(mcp-description) … |##` (single-line `##(mcp-description) text` also
+ * accepted). The marker body doubles as the model's AI-facing description.
+ * The marker gates every operation here, so the exposed surface is exactly
+ * the set of marked `.malloy` files under the model root.
+ */
+
+/** A model exposed to restricted clients. */
+export interface ModelEntry {
+  /** Path relative to the model root, e.g. `sales/orders.malloy`. */
+  handle: string;
+  /** The `(mcp-description)` marker body, if any text was supplied. */
+  description?: string;
+}
+
+// The opt-in marker, in its two accepted forms. Both anchor to the start of a
+// line (after optional indentation): the block opener `##|(mcp-description)`
+// and the single-line `##(mcp-description)`.
+const BLOCK_OPENER = /^([ \t]*)##\|\(mcp-description\)[ \t]*$/;
+const LINE_FORM = /^[ \t]*##\(mcp-description\)[ \t]?(.*)$/;
+
+/** Cheap test (no compile) for whether source text opts the model in. */
+function hasMarker(text: string): boolean {
+  return text
+    .split('\n')
+    .some(line => BLOCK_OPENER.test(line) || LINE_FORM.test(line));
+}
+
+/**
+ * Pull the `(mcp-description)` body out of source text without compiling.
+ * Block form: every line between the `##|(mcp-description)` opener and the
+ * `|##` closer (at the opener's column), de-indented. Single-line form: the
+ * text trailing the marker. Returns undefined when no marker, or the marker
+ * carried no body.
+ */
+export function extractDescription(text: string): string | undefined {
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const block = BLOCK_OPENER.exec(lines[i]);
+    if (block) {
+      const indent = block[1];
+      const body: string[] = [];
+      for (let j = i + 1; j < lines.length; j++) {
+        if (/^[ \t]*\|##[ \t]*$/.test(lines[j])) {
+          const desc = body
+            .map(l => (l.startsWith(indent) ? l.slice(indent.length) : l))
+            .join('\n')
+            .trim();
+          return desc.length > 0 ? desc : undefined;
+        }
+        body.push(lines[j]);
+      }
+      // Unterminated block — treat the opener as a marker with no usable body.
+      return undefined;
+    }
+    const line = LINE_FORM.exec(lines[i]);
+    if (line) {
+      const desc = line[1].trim();
+      return desc.length > 0 ? desc : undefined;
+    }
+  }
+  return undefined;
+}
+
+function notFound(handle: string): Problem {
+  return {
+    severity: 'error',
+    code: 'model-not-found',
+    message:
+      `No published model '${handle}'. Models are exposed by carrying the ` +
+      '`##|(mcp-description) … |##` marker; call list_models to see what is ' +
+      'available.',
+  };
+}
+
+/**
+ * Resolve a client-supplied handle to an absolute path, enforcing the trust
+ * boundary: the handle must stay inside the model root (no absolute paths, no
+ * `..` traversal), name an existing `.malloy` file, and carry the opt-in
+ * marker. Anything else is reported as `model-not-found` so the boundary
+ * never leaks why a path was rejected.
+ */
+export function resolveHandle(
+  root: string,
+  handle: string
+): {abs: string} | {problem: Problem} {
+  if (path.isAbsolute(handle) || handle.includes('\0')) {
+    return {problem: notFound(handle)};
+  }
+  const abs = path.resolve(root, handle);
+  const rel = path.relative(root, abs);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    return {problem: notFound(handle)};
+  }
+  if (!abs.endsWith('.malloy') || !fs.existsSync(abs)) {
+    return {problem: notFound(handle)};
+  }
+  let text: string;
+  try {
+    text = fs.readFileSync(abs, 'utf8');
+  } catch {
+    return {problem: notFound(handle)};
+  }
+  if (!hasMarker(text)) {
+    return {problem: notFound(handle)};
+  }
+  return {abs};
+}
+
+function walkMalloyFiles(dir: string, out: string[]): void {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, {withFileTypes: true});
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkMalloyFiles(full, out);
+    } else if (entry.isFile() && entry.name.endsWith('.malloy')) {
+      out.push(full);
+    }
+  }
+}
+
+/**
+ * Enumerate published models under the root: every `.malloy` file carrying
+ * the marker, by relative handle, with its description. No compilation.
+ */
+export function listModels(root: string): ModelEntry[] {
+  const files: string[] = [];
+  walkMalloyFiles(root, files);
+  const models: ModelEntry[] = [];
+  for (const abs of files) {
+    let text: string;
+    try {
+      text = fs.readFileSync(abs, 'utf8');
+    } catch {
+      continue;
+    }
+    if (!hasMarker(text)) continue;
+    const handle = path.relative(root, abs).split(path.sep).join('/');
+    const description = extractDescription(text);
+    models.push(description ? {handle, description} : {handle});
+  }
+  models.sort((a, b) => a.handle.localeCompare(b.handle));
+  return models;
+}
+
+/** Curated surface of one published model (reuses the open compile path). */
+export async function describeModel(
+  root: string,
+  handle: string,
+  opts: CompileOptions = {}
+): Promise<CompileResult> {
+  const resolved = resolveHandle(root, handle);
+  if ('problem' in resolved) {
+    return {ok: false, problems: [resolved.problem]};
+  }
+  return compile({uri: resolved.abs}, opts);
+}
+
+/**
+ * Compile (validate only) restricted query text against a published model.
+ * Non-throwing: returns the full problem list, including any
+ * `restricted-construct-forbidden` rejections.
+ */
+export async function compileRestricted(
+  root: string,
+  handle: string,
+  query: string
+): Promise<{ok: boolean; problems: Problem[]}> {
+  const resolved = resolveHandle(root, handle);
+  if ('problem' in resolved) {
+    return {ok: false, problems: [resolved.problem]};
+  }
+  const loadRes = await loadModel({uri: resolved.abs});
+  if (!loadRes.ok || !loadRes.loaded) {
+    return {ok: false, problems: loadRes.problems};
+  }
+  const {runtime, rootUrl} = loadRes.loaded;
+  try {
+    const q = runtime.loadModel(rootUrl).loadRestrictedQuery(query);
+    const problems = mapProblems(await q.validate());
+    const hasError = problems.some(p => p.severity === 'error');
+    return {ok: !hasError, problems: [...loadRes.problems, ...problems]};
+  } catch (e) {
+    if (e instanceof MalloyError) {
+      return {
+        ok: false,
+        problems: [...loadRes.problems, ...mapProblems(e.problems)],
+      };
+    }
+    return {ok: false, problems: [...loadRes.problems, errorProblem(e)]};
+  }
+}
+
+/**
+ * Execute restricted query text against a published model. Mirrors the open
+ * `run` result shape (SQL + rows + timing) and the same error handling, but
+ * the query compiles in restricted mode and the model is selected by handle.
+ */
+export async function runRestricted(
+  root: string,
+  handle: string,
+  query: string,
+  selector: Pick<RunSelector, 'rowLimit' | 'givens'> = {}
+): Promise<RunResult> {
+  const resolved = resolveHandle(root, handle);
+  if ('problem' in resolved) {
+    return {ok: false, problems: [resolved.problem]};
+  }
+  const loadRes = await loadModel({uri: resolved.abs});
+  if (!loadRes.ok || !loadRes.loaded) {
+    return {ok: false, problems: loadRes.problems};
+  }
+  const {runtime, rootUrl} = loadRes.loaded;
+  const rowLimit = selector.rowLimit ?? DEFAULT_ROW_LIMIT;
+  const givenOpts: {givens?: Record<string, GivenValue>} = selector.givens
+    ? {givens: selector.givens}
+    : {};
+  try {
+    const q = runtime.loadModel(rootUrl).loadRestrictedQuery(query);
+    const t0 = Date.now();
+    const sql = (await q.getSQL(givenOpts)).trim();
+    const t1 = Date.now();
+    const results = await withDuckdbLockRetry(() =>
+      q.run({rowLimit, ...givenOpts})
+    );
+    const t2 = Date.now();
+    const rows = results.toJSON().queryResult.result;
+    return {
+      ok: true,
+      sql,
+      rowCount: rows.length,
+      truncated: rows.length === rowLimit,
+      rows,
+      compileTimeMS: t1 - t0,
+      totalTimeMS: t2 - t0,
+      problems: loadRes.problems,
+    };
+  } catch (e) {
+    if (e instanceof MalloyError) {
+      return {
+        ok: false,
+        problems: [...loadRes.problems, ...mapProblems(e.problems)],
+      };
+    }
+    return {ok: false, problems: [...loadRes.problems, errorProblem(e)]};
+  }
+}
+
+/**
+ * Resolve the directory whose marked `.malloy` files the restricted server
+ * publishes. This is the `-p DIR` project dir, passed through from the CLI;
+ * restricted mode is meaningless without it.
+ */
+export function resolveModelRoot(projectDir: string | undefined): string {
+  if (!projectDir) {
+    throw new Error(
+      'Restricted MCP mode (--restricted) requires a project directory: ' +
+        'pass -p DIR to scope which models are exposed.'
+    );
+  }
+  return path.resolve(projectDir);
+}

--- a/src/mcp/restricted.ts
+++ b/src/mcp/restricted.ts
@@ -2,57 +2,37 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import {MalloyError, GivenValue} from '@malloydata/malloy';
+import {MalloyError} from '@malloydata/malloy';
 import {Problem, loadModel, mapProblems, errorProblem} from './loader';
 import {compile, CompileResult, CompileOptions} from './compile';
-import {RunResult, RunSelector} from './run';
+import {RunResult, RunSelector, executeMaterializedQuery} from './run';
 import {DEFAULT_ROW_LIMIT} from '../malloy/util';
-import {withDuckdbLockRetry} from '../util';
+import {findMalloyFiles, isHiddenPathSegment, isMalloyFile} from '../util';
 
 /**
- * Restricted-mode MCP surface. The trust boundary: an untrusted agent picks
- * one of the operator's *published* models by handle and submits restricted
- * query text that compiles against it. The agent never supplies a file URI,
- * an `import`, or any of the SQL escape hatches — malloy core's
- * `loadRestrictedQuery` rejects those at translate time.
- *
- * A model is published only if it carries the opt-in marker annotation
- * `##|(mcp-description) … |##` (single-line `##(mcp-description) text` also
- * accepted). The marker body doubles as the model's AI-facing description.
- * The marker gates every operation here, so the exposed surface is exactly
- * the set of marked `.malloy` files under the model root.
+ * The trust boundary: an agent picks one of the operator's published models
+ * by handle and submits restricted query text. A model is published only by
+ * carrying the opt-in marker `##|(mcp-description) … |##`; restricted text is
+ * enforced by core's `loadRestrictedQuery`.
  */
 
-/** A model exposed to restricted clients. */
 export interface ModelEntry {
   /** Path relative to the model root, e.g. `sales/orders.malloy`. */
   handle: string;
-  /** The `(mcp-description)` marker body, if any text was supplied. */
   description?: string;
 }
 
-// The opt-in marker, in its two accepted forms. Both anchor to the start of a
-// line (after optional indentation): the block opener `##|(mcp-description)`
-// and the single-line `##(mcp-description)`.
 const BLOCK_OPENER = /^([ \t]*)##\|\(mcp-description\)[ \t]*$/;
 const LINE_FORM = /^[ \t]*##\(mcp-description\)[ \t]?(.*)$/;
 
-/** Cheap test (no compile) for whether source text opts the model in. */
 function hasMarker(text: string): boolean {
   return text
-    .split('\n')
+    .split(/\r?\n/)
     .some(line => BLOCK_OPENER.test(line) || LINE_FORM.test(line));
 }
 
-/**
- * Pull the `(mcp-description)` body out of source text without compiling.
- * Block form: every line between the `##|(mcp-description)` opener and the
- * `|##` closer (at the opener's column), de-indented. Single-line form: the
- * text trailing the marker. Returns undefined when no marker, or the marker
- * carried no body.
- */
 export function extractDescription(text: string): string | undefined {
-  const lines = text.split('\n');
+  const lines = text.split(/\r?\n/);
   for (let i = 0; i < lines.length; i++) {
     const block = BLOCK_OPENER.exec(lines[i]);
     if (block) {
@@ -68,7 +48,6 @@ export function extractDescription(text: string): string | undefined {
         }
         body.push(lines[j]);
       }
-      // Unterminated block — treat the opener as a marker with no usable body.
       return undefined;
     }
     const line = LINE_FORM.exec(lines[i]);
@@ -92,11 +71,11 @@ function notFound(handle: string): Problem {
 }
 
 /**
- * Resolve a client-supplied handle to an absolute path, enforcing the trust
- * boundary: the handle must stay inside the model root (no absolute paths, no
- * `..` traversal), name an existing `.malloy` file, and carry the opt-in
- * marker. Anything else is reported as `model-not-found` so the boundary
- * never leaks why a path was rejected.
+ * Resolve a client-supplied handle to a path inside the model root. The
+ * checks here are the trust boundary; every rejection returns the same
+ * `model-not-found` so a probe can't learn why a path was refused. The
+ * excluded-segment check keeps the reachable set equal to what `listModels`
+ * (via `findMalloyFiles`) enumerates.
  */
 export function resolveHandle(
   root: string,
@@ -110,7 +89,10 @@ export function resolveHandle(
   if (rel.startsWith('..') || path.isAbsolute(rel)) {
     return {problem: notFound(handle)};
   }
-  if (!abs.endsWith('.malloy') || !fs.existsSync(abs)) {
+  if (rel.split(path.sep).some(isHiddenPathSegment)) {
+    return {problem: notFound(handle)};
+  }
+  if (!isMalloyFile(abs) || !fs.existsSync(abs)) {
     return {problem: notFound(handle)};
   }
   let text: string;
@@ -125,33 +107,9 @@ export function resolveHandle(
   return {abs};
 }
 
-function walkMalloyFiles(dir: string, out: string[]): void {
-  let entries: fs.Dirent[];
-  try {
-    entries = fs.readdirSync(dir, {withFileTypes: true});
-  } catch {
-    return;
-  }
-  for (const entry of entries) {
-    if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      walkMalloyFiles(full, out);
-    } else if (entry.isFile() && entry.name.endsWith('.malloy')) {
-      out.push(full);
-    }
-  }
-}
-
-/**
- * Enumerate published models under the root: every `.malloy` file carrying
- * the marker, by relative handle, with its description. No compilation.
- */
 export function listModels(root: string): ModelEntry[] {
-  const files: string[] = [];
-  walkMalloyFiles(root, files);
   const models: ModelEntry[] = [];
-  for (const abs of files) {
+  for (const abs of findMalloyFiles(root)) {
     let text: string;
     try {
       text = fs.readFileSync(abs, 'utf8');
@@ -167,7 +125,6 @@ export function listModels(root: string): ModelEntry[] {
   return models;
 }
 
-/** Curated surface of one published model (reuses the open compile path). */
 export async function describeModel(
   root: string,
   handle: string,
@@ -180,11 +137,7 @@ export async function describeModel(
   return compile({uri: resolved.abs}, opts);
 }
 
-/**
- * Compile (validate only) restricted query text against a published model.
- * Non-throwing: returns the full problem list, including any
- * `restricted-construct-forbidden` rejections.
- */
+/** Validate (no execution) restricted query text against a published model. */
 export async function compileRestricted(
   root: string,
   handle: string,
@@ -215,11 +168,6 @@ export async function compileRestricted(
   }
 }
 
-/**
- * Execute restricted query text against a published model. Mirrors the open
- * `run` result shape (SQL + rows + timing) and the same error handling, but
- * the query compiles in restricted mode and the model is selected by handle.
- */
 export async function runRestricted(
   root: string,
   handle: string,
@@ -235,46 +183,15 @@ export async function runRestricted(
     return {ok: false, problems: loadRes.problems};
   }
   const {runtime, rootUrl} = loadRes.loaded;
-  const rowLimit = selector.rowLimit ?? DEFAULT_ROW_LIMIT;
-  const givenOpts: {givens?: Record<string, GivenValue>} = selector.givens
-    ? {givens: selector.givens}
-    : {};
-  try {
-    const q = runtime.loadModel(rootUrl).loadRestrictedQuery(query);
-    const t0 = Date.now();
-    const sql = (await q.getSQL(givenOpts)).trim();
-    const t1 = Date.now();
-    const results = await withDuckdbLockRetry(() =>
-      q.run({rowLimit, ...givenOpts})
-    );
-    const t2 = Date.now();
-    const rows = results.toJSON().queryResult.result;
-    return {
-      ok: true,
-      sql,
-      rowCount: rows.length,
-      truncated: rows.length === rowLimit,
-      rows,
-      compileTimeMS: t1 - t0,
-      totalTimeMS: t2 - t0,
-      problems: loadRes.problems,
-    };
-  } catch (e) {
-    if (e instanceof MalloyError) {
-      return {
-        ok: false,
-        problems: [...loadRes.problems, ...mapProblems(e.problems)],
-      };
-    }
-    return {ok: false, problems: [...loadRes.problems, errorProblem(e)]};
-  }
+  const q = runtime.loadModel(rootUrl).loadRestrictedQuery(query);
+  return executeMaterializedQuery(
+    q,
+    selector.rowLimit ?? DEFAULT_ROW_LIMIT,
+    selector.givens,
+    loadRes.problems
+  );
 }
 
-/**
- * Resolve the directory whose marked `.malloy` files the restricted server
- * publishes. This is the `-p DIR` project dir, passed through from the CLI;
- * restricted mode is meaningless without it.
- */
 export function resolveModelRoot(projectDir: string | undefined): string {
   if (!projectDir) {
     throw new Error(

--- a/src/mcp/run.ts
+++ b/src/mcp/run.ts
@@ -1,6 +1,6 @@
 /* Copyright Contributors to the Malloy project / SPDX-License-Identifier: MIT */
 
-import {MalloyError, GivenValue} from '@malloydata/malloy';
+import {MalloyError, GivenValue, QueryMaterializer} from '@malloydata/malloy';
 import {
   SourceInput,
   Problem,
@@ -61,66 +61,85 @@ export async function run(
   }
   const {model, rootUrl, runtime} = loadRes.loaded;
   const modelQueries = model.queries();
+  const materializer = runtime.loadModel(rootUrl);
 
-  try {
-    const materializer = runtime.loadModel(rootUrl);
-    let query;
-    if (selector.name) {
-      if (!modelQueries.named.includes(selector.name)) {
-        const available = {
-          queries: modelQueries.named,
-          runs: modelQueries.unnamed,
-        };
-        return {
-          ok: false,
-          problems: [
-            {
-              severity: 'error',
-              code: 'selector-not-found',
-              message: `No query named '${
-                selector.name
-              }'. Available: ${JSON.stringify(available)}`,
-              uri: rootUrl.href,
-            },
-          ],
-        };
-      }
-      query = materializer.loadQueryByName(selector.name);
-    } else if (typeof selector.index === 'number') {
-      if (selector.index < 0 || selector.index >= modelQueries.unnamed) {
-        return {
-          ok: false,
-          problems: [
-            {
-              severity: 'error',
-              code: 'selector-out-of-range',
-              message: `Index ${selector.index} out of range; file has ${modelQueries.unnamed} run: statement(s).`,
-              uri: rootUrl.href,
-            },
-          ],
-        };
-      }
-      query = materializer.loadQueryByIndex(selector.index);
-    } else {
-      if (modelQueries.unnamed === 0) {
-        return {
-          ok: false,
-          problems: [
-            {
-              severity: 'error',
-              code: 'no-run',
-              message:
-                'Source has no run: statement. Specify a named query via `name`, or add a run: to the source.',
-              uri: rootUrl.href,
-            },
-          ],
-        };
-      }
-      query = materializer.loadFinalQuery();
+  let query: QueryMaterializer;
+  if (selector.name) {
+    if (!modelQueries.named.includes(selector.name)) {
+      const available = {
+        queries: modelQueries.named,
+        runs: modelQueries.unnamed,
+      };
+      return {
+        ok: false,
+        problems: [
+          {
+            severity: 'error',
+            code: 'selector-not-found',
+            message: `No query named '${
+              selector.name
+            }'. Available: ${JSON.stringify(available)}`,
+            uri: rootUrl.href,
+          },
+        ],
+      };
     }
+    query = materializer.loadQueryByName(selector.name);
+  } else if (typeof selector.index === 'number') {
+    if (selector.index < 0 || selector.index >= modelQueries.unnamed) {
+      return {
+        ok: false,
+        problems: [
+          {
+            severity: 'error',
+            code: 'selector-out-of-range',
+            message: `Index ${selector.index} out of range; file has ${modelQueries.unnamed} run: statement(s).`,
+            uri: rootUrl.href,
+          },
+        ],
+      };
+    }
+    query = materializer.loadQueryByIndex(selector.index);
+  } else {
+    if (modelQueries.unnamed === 0) {
+      return {
+        ok: false,
+        problems: [
+          {
+            severity: 'error',
+            code: 'no-run',
+            message:
+              'Source has no run: statement. Specify a named query via `name`, or add a run: to the source.',
+            uri: rootUrl.href,
+          },
+        ],
+      };
+    }
+    query = materializer.loadFinalQuery();
+  }
 
-    const rowLimit = selector.rowLimit ?? DEFAULT_ROW_LIMIT;
-    const compileOpts = selector.givens ? {givens: selector.givens} : undefined;
+  return executeMaterializedQuery(
+    query,
+    selector.rowLimit ?? DEFAULT_ROW_LIMIT,
+    selector.givens,
+    loadRes.problems,
+    {nudge: p => nudgeIfFieldNotFound(p, input), uri: rootUrl.href}
+  );
+}
+
+/**
+ * Run a materialized query and shape the uniform RunResult. Shared by the open
+ * `run` and the restricted run path.
+ */
+export async function executeMaterializedQuery(
+  query: QueryMaterializer,
+  rowLimit: number,
+  givens: Record<string, GivenValue> | undefined,
+  loadProblems: Problem[],
+  opts: {nudge?: (p: Problem) => Problem; uri?: string} = {}
+): Promise<RunResult> {
+  const compileOpts = givens ? {givens} : undefined;
+  try {
     const t0 = Date.now();
     const sql = (await query.getSQL(compileOpts)).trim();
     const t1 = Date.now();
@@ -128,33 +147,26 @@ export async function run(
       query.run({rowLimit, ...compileOpts})
     );
     const t2 = Date.now();
-    const json = results.toJSON();
-    const rows = json.queryResult.result;
-    const truncated = rows.length === rowLimit;
+    const rows = results.toJSON().queryResult.result;
     return {
       ok: true,
       sql,
       rowCount: rows.length,
-      truncated,
+      truncated: rows.length === rowLimit,
       rows,
       compileTimeMS: t1 - t0,
       totalTimeMS: t2 - t0,
-      problems: loadRes.problems,
+      problems: loadProblems,
     };
   } catch (e) {
+    const nudge = opts.nudge ?? ((p: Problem) => p);
     if (e instanceof MalloyError) {
       return {
         ok: false,
-        problems: [
-          ...loadRes.problems,
-          ...mapProblems(e.problems).map(p => nudgeIfFieldNotFound(p, input)),
-        ],
+        problems: [...loadProblems, ...mapProblems(e.problems).map(nudge)],
       };
     }
-    return {
-      ok: false,
-      problems: [...loadRes.problems, errorProblem(e, rootUrl.href)],
-    };
+    return {ok: false, problems: [...loadProblems, errorProblem(e, opts.uri)]};
   }
 }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -6,6 +6,13 @@ import {GivenValue} from '@malloydata/malloy';
 import {z} from 'zod';
 import {compile, listRuns} from './compile';
 import {run} from './run';
+import {
+  listModels,
+  describeModel,
+  compileRestricted,
+  runRestricted,
+  resolveModelRoot,
+} from './restricted';
 import {listTopics, getTopic} from './help';
 import {loadSkills, skillsDir} from './skills';
 import {malloyConfig} from '../config';
@@ -43,6 +50,12 @@ const uriSchema = z
 
 const sourceSchema = z.string().describe('Malloy source code.');
 
+const rowLimitSchema = z
+  .number()
+  .int()
+  .optional()
+  .describe('Maximum number of rows to return. Defaults to 10000.');
+
 const givensSchema = z
   .record(z.string(), z.unknown())
   .optional()
@@ -65,6 +78,27 @@ const baseUriSchema = z
     'Optional URI used to resolve relative imports in the inline source. ' +
       'Typically the file:// URI of the file the snippet will live next to. ' +
       'If omitted, imports must be absolute.'
+  );
+
+const modelSchema = z
+  .string()
+  .describe(
+    'Handle of a published model, as returned by `list_models` (a path ' +
+      'relative to the server\'s model root, e.g. "sales/orders.malloy"). ' +
+      'You cannot name an arbitrary file — only published models are ' +
+      'reachable.'
+  );
+
+const restrictedQuerySchema = z
+  .string()
+  .describe(
+    'Malloy query text to compile against the chosen model. May contain ' +
+      '`source:` / `query:` / `run:` statements and reference anything the ' +
+      'model already defines, plus `$NAME` givens it declared. May NOT use ' +
+      '`import`, declare `given:`, call `connection.table(...)` / ' +
+      '`connection.sql(...)`, use the `name!type(...)` raw-SQL form or the ' +
+      '`sql_*` functions, or set `##!` compiler flags — those are rejected ' +
+      'with code `restricted-construct-forbidden`.'
   );
 
 /**
@@ -90,6 +124,15 @@ function toContent(result: object) {
     content: [{type: 'text' as const, text: JSON.stringify(result, null, 2)}],
     structuredContent,
   };
+}
+
+// After every tool call, idle (not close) the connection cache so the next
+// call transparently reattaches with its schema cache intact while file
+// locks / pooled sockets are released between calls. Lets a co-running
+// DuckDB process (e.g., a VS Code extension or a separate CLI invocation)
+// acquire the same DB file.
+async function idleConnections(): Promise<void> {
+  await malloyConfig.shutdown('idle');
 }
 
 const SERVER_INSTRUCTIONS = `
@@ -160,24 +203,143 @@ It describes the .malloynb cell format, how to ask for the target file
 if one hasn't been specified, and what to append.
 `.trim();
 
-export async function runMcpServer(): Promise<void> {
-  // After every tool call, idle (not close) the connection cache so the next
-  // call transparently reattaches with its schema cache intact while file
-  // locks / pooled sockets are released between calls. Lets a co-running
-  // DuckDB process (e.g., a VS Code extension or a separate CLI invocation)
-  // acquire the same DB file.
-  async function idleConnections(): Promise<void> {
-    await malloyConfig.shutdown('idle');
-  }
+const RESTRICTED_INSTRUCTIONS = `
+This server exposes a curated set of Malloy models and lets you query them.
+You cannot open files by path, import other files, reach raw tables, or write
+SQL — only ask questions of the published models, in Malloy.
 
-  const server = new McpServer(
+## Workflow
+
+1. \`list_models\` — discover the models you can query. Each entry has a
+   \`handle\` (pass it as \`model\`) and a \`description\` from the model author.
+2. \`describe_model\` — inspect one model's curated surface: its sources with
+   dimensions / measures / views / joins, named queries, and givens. This is
+   how you learn what is queryable before writing anything.
+3. \`compile\` — validate your Malloy \`query\` against a model without running
+   it. Iterate on the returned \`problems[]\` until clean.
+4. \`run\` — execute the query and get SQL + rows.
+
+## What restricted query text may and may not do
+
+Your \`query\` may contain \`source:\`, \`query:\`, and \`run:\` statements, freely
+reference anything the model already defines (sources, measures, dimensions,
+views, joins), and reference \`$NAME\` givens the model declared (supply values
+via the \`givens\` map on \`run\`).
+
+It may NOT \`import\`, declare new \`given:\`s, call \`connection.table(...)\` or
+\`connection.sql(...)\`, use the \`name!type(...)\` raw-SQL form or the \`sql_*\`
+functions, or set \`##!\` compiler flags. These are rejected with code
+\`restricted-construct-forbidden\`. The model author already vouched for
+whatever the model's own definitions use, so a model field defined with
+\`connection.sql(...)\` is still fine to reference.
+
+## Always show the Malloy source and timing
+
+After every \`run\` or \`compile\`, show the user the Malloy query you submitted
+(even on error) and, on a successful run, \`totalTimeMS\` as
+"X ms total (Y ms compile)".
+
+When you need Malloy syntax, call \`language_help(topic)\` before guessing, and
+again after any compile error whose fix is not obvious.
+`.trim();
+
+/** Tools safe in any mode — they touch neither the filesystem nor connections. */
+function registerSharedTools(server: McpServer): void {
+  // ------------------------------------------------------------------
+  // prettify — reformat a Malloy source string.
+  // ------------------------------------------------------------------
+  server.registerTool(
+    'prettify',
     {
-      name: 'malloy-cli',
-      version: pkg.version ?? 'development',
+      title: 'Pretty-print Malloy source',
+      description:
+        'Reformat a Malloy source string. Returns the formatted source and ' +
+        'any parse errors (lexer + parser only — semantic errors are not ' +
+        'checked here; use `compile` for that). When `errors` is non-empty ' +
+        'the formatted output is best-effort and may not round-trip; fix the ' +
+        'parse errors first. Useful for cleaning up freshly-authored or ' +
+        'machine-generated Malloy before saving.',
+      inputSchema: {source: sourceSchema},
     },
-    {instructions: SERVER_INSTRUCTIONS}
+    async ({source}) => toContent(prettifyMalloy(source))
   );
 
+  // ------------------------------------------------------------------
+  // language_help — topic-indexed slice of the Malloy language reference.
+  // ------------------------------------------------------------------
+  server.registerTool(
+    'language_help',
+    {
+      title: 'Malloy language reference (by topic)',
+      description:
+        'Look up a section of the Malloy language reference by topic slug ' +
+        'or title. Call this before guessing syntax — especially for ' +
+        'pipelines, reduction vs projection, aggregate locality, ' +
+        'calculations/window functions, filtered aggregates, pick ' +
+        'expressions, time ranges, tags/annotations. Also call this after ' +
+        'any compile error whose fix is not obvious from the message — ' +
+        "problems[] entries carry a `help_topic` field when there's a " +
+        'natural match. Call with no topic to list the available topics.',
+      inputSchema: {
+        topic: z
+          .string()
+          .optional()
+          .describe(
+            'Topic slug or title to look up (case-insensitive; substrings ' +
+              'match). Omit to list all available topics.'
+          ),
+      },
+    },
+    async ({topic}) => {
+      if (!topic) {
+        return toContent({topics: listTopics()});
+      }
+      const hit = getTopic(topic);
+      if (!hit) {
+        return toContent({
+          error: `No topic matches '${topic}'.`,
+          topics: listTopics(),
+        });
+      }
+      return toContent({
+        slug: hit.slug,
+        title: hit.title,
+        body: hit.body,
+      });
+    }
+  );
+
+  // ------------------------------------------------------------------
+  // Skills: language-reference prompts + resources, no NL→Malloy tool.
+  // ------------------------------------------------------------------
+  const skills = loadSkills(skillsDir());
+  for (const skill of skills) {
+    server.registerPrompt(
+      skill.name,
+      {title: skill.name, description: skill.description},
+      () => ({
+        messages: [{role: 'user', content: {type: 'text', text: skill.body}}],
+      })
+    );
+    server.registerResource(
+      skill.name,
+      `malloy-skill://${skill.name}`,
+      {
+        title: skill.name,
+        description: skill.description,
+        mimeType: 'text/markdown',
+      },
+      async uri => ({
+        contents: [
+          {uri: uri.href, mimeType: 'text/markdown', text: skill.body},
+        ],
+      })
+    );
+  }
+}
+
+/** The open toolset: arbitrary file URIs and inline source (trusted operator). */
+function registerOpenTools(server: McpServer): void {
   // ------------------------------------------------------------------
   // compile_file — fetch and compile a .malloy file by URI.
   // ------------------------------------------------------------------
@@ -274,11 +436,7 @@ export async function runMcpServer(): Promise<void> {
           .int()
           .optional()
           .describe('0-based index into run: statements.'),
-        row_limit: z
-          .number()
-          .int()
-          .optional()
-          .describe('Maximum number of rows to return. Defaults to 10000.'),
+        row_limit: rowLimitSchema,
         givens: givensSchema,
       },
     },
@@ -309,11 +467,7 @@ export async function runMcpServer(): Promise<void> {
       inputSchema: {
         source: sourceSchema,
         base_uri: baseUriSchema,
-        row_limit: z
-          .number()
-          .int()
-          .optional()
-          .describe('Maximum number of rows to return. Defaults to 10000.'),
+        row_limit: rowLimitSchema,
         givens: givensSchema,
       },
     },
@@ -324,70 +478,6 @@ export async function runMcpServer(): Promise<void> {
       );
       await idleConnections();
       return toContent(result);
-    }
-  );
-
-  // ------------------------------------------------------------------
-  // prettify — reformat a Malloy source string.
-  // ------------------------------------------------------------------
-  server.registerTool(
-    'prettify',
-    {
-      title: 'Pretty-print Malloy source',
-      description:
-        'Reformat a Malloy source string. Returns the formatted source and ' +
-        'any parse errors (lexer + parser only — semantic errors are not ' +
-        'checked here; use `compile` for that). When `errors` is non-empty ' +
-        'the formatted output is best-effort and may not round-trip; fix the ' +
-        'parse errors first. Useful for cleaning up freshly-authored or ' +
-        'machine-generated Malloy before saving.',
-      inputSchema: {source: sourceSchema},
-    },
-    async ({source}) => toContent(prettifyMalloy(source))
-  );
-
-  // ------------------------------------------------------------------
-  // language_help — topic-indexed slice of the Malloy language reference.
-  // ------------------------------------------------------------------
-  server.registerTool(
-    'language_help',
-    {
-      title: 'Malloy language reference (by topic)',
-      description:
-        'Look up a section of the Malloy language reference by topic slug ' +
-        'or title. Call this before guessing syntax — especially for ' +
-        'pipelines, reduction vs projection, aggregate locality, ' +
-        'calculations/window functions, filtered aggregates, pick ' +
-        'expressions, time ranges, tags/annotations. Also call this after ' +
-        'any compile error whose fix is not obvious from the message — ' +
-        "problems[] entries carry a `help_topic` field when there's a " +
-        'natural match. Call with no topic to list the available topics.',
-      inputSchema: {
-        topic: z
-          .string()
-          .optional()
-          .describe(
-            'Topic slug or title to look up (case-insensitive; substrings ' +
-              'match). Omit to list all available topics.'
-          ),
-      },
-    },
-    async ({topic}) => {
-      if (!topic) {
-        return toContent({topics: listTopics()});
-      }
-      const hit = getTopic(topic);
-      if (!hit) {
-        return toContent({
-          error: `No topic matches '${topic}'.`,
-          topics: listTopics(),
-        });
-      }
-      return toContent({
-        slug: hit.slug,
-        title: hit.title,
-        body: hit.body,
-      });
     }
   );
 
@@ -415,34 +505,141 @@ export async function runMcpServer(): Promise<void> {
       return toContent(result);
     }
   );
+}
+
+/**
+ * The restricted toolset: an agent selects a published model by handle and
+ * submits restricted query text. No arbitrary URIs, no inline `import`.
+ */
+function registerRestrictedTools(server: McpServer, root: string): void {
+  // ------------------------------------------------------------------
+  // list_models — published models the agent may query.
+  // ------------------------------------------------------------------
+  server.registerTool(
+    'list_models',
+    {
+      title: 'List published Malloy models',
+      description:
+        'List the models this server exposes. Each entry has a `handle` ' +
+        '(pass it as `model` to describe_model / compile / run) and a ' +
+        '`description` written by the model author. These are the only ' +
+        'models you can query — you cannot open files by path or import ' +
+        'anything else.',
+      inputSchema: {},
+    },
+    async () => toContent({models: listModels(root)})
+  );
 
   // ------------------------------------------------------------------
-  // Skills: language-reference prompts + resources, no NL→Malloy tool.
+  // describe_model — curated surface of one published model.
   // ------------------------------------------------------------------
-  const skills = loadSkills(skillsDir());
-  for (const skill of skills) {
-    server.registerPrompt(
-      skill.name,
-      {title: skill.name, description: skill.description},
-      () => ({
-        messages: [{role: 'user', content: {type: 'text', text: skill.body}}],
-      })
-    );
-    server.registerResource(
-      skill.name,
-      `malloy-skill://${skill.name}`,
-      {
-        title: skill.name,
-        description: skill.description,
-        mimeType: 'text/markdown',
+  server.registerTool(
+    'describe_model',
+    {
+      title: 'Inspect a published model',
+      description:
+        'Return the curated semantic surface of a published model: sources ' +
+        '(with dimensions, measures, views, joins), named queries, and ' +
+        'givens. Pick `model` from `list_models`. This is how you learn ' +
+        'what is queryable before writing a restricted query — prefer it ' +
+        'over guessing field names.',
+      inputSchema: {
+        model: modelSchema,
+        expand: expandSchema,
+        emit_run_sql: emitRunSqlSchema,
       },
-      async uri => ({
-        contents: [
-          {uri: uri.href, mimeType: 'text/markdown', text: skill.body},
-        ],
-      })
-    );
+    },
+    async ({model, expand, emit_run_sql}) => {
+      const result = await describeModel(root, model, {
+        expand,
+        emitRunSql: emit_run_sql,
+      });
+      await idleConnections();
+      return toContent(result);
+    }
+  );
+
+  // ------------------------------------------------------------------
+  // compile — validate restricted query text against a model.
+  // ------------------------------------------------------------------
+  server.registerTool(
+    'compile',
+    {
+      title: 'Validate a restricted query against a model',
+      description:
+        'Compile (validate only, no execution) Malloy `query` text against ' +
+        'the published `model`. Returns `problems[]`; iterate until clean, ' +
+        'then `run`. Forbidden constructs (import, given: declarations, ' +
+        'connection.table/sql, name!type(...), the sql_* functions, ##! ' +
+        'flags) are rejected with code `restricted-construct-forbidden`.',
+      inputSchema: {model: modelSchema, query: restrictedQuerySchema},
+    },
+    async ({model, query}) => {
+      const result = await compileRestricted(root, model, query);
+      await idleConnections();
+      return toContent(result);
+    }
+  );
+
+  // ------------------------------------------------------------------
+  // run — execute restricted query text against a model.
+  // ------------------------------------------------------------------
+  server.registerTool(
+    'run',
+    {
+      title: 'Run a restricted query against a model',
+      description:
+        'Compile `query` against the published `model` in restricted mode ' +
+        "and execute it against the operator's configured connections. " +
+        'Returns the generated SQL and rows (default 10000, set row_limit ' +
+        'to override). Supply values for any `$NAME` givens the model ' +
+        'declares via the `givens` map. Same restrictions as `compile`.',
+      inputSchema: {
+        model: modelSchema,
+        query: restrictedQuerySchema,
+        row_limit: rowLimitSchema,
+        givens: givensSchema,
+      },
+    },
+    async ({model, query, row_limit, givens}) => {
+      const result = await runRestricted(root, model, query, {
+        rowLimit: row_limit,
+        givens: asGivens(givens),
+      });
+      await idleConnections();
+      return toContent(result);
+    }
+  );
+}
+
+export interface McpServerOptions {
+  /** Serve only curated models from `projectDir`, with restricted queries. */
+  restricted?: boolean;
+  /** The `-p DIR` project dir; the model root when `restricted` is set. */
+  projectDir?: string;
+}
+
+export async function runMcpServer(opts: McpServerOptions = {}): Promise<void> {
+  const root = opts.restricted ? resolveModelRoot(opts.projectDir) : undefined;
+
+  const server = new McpServer(
+    {
+      name: 'malloy-cli',
+      version: pkg.version ?? 'development',
+    },
+    {
+      instructions: opts.restricted
+        ? RESTRICTED_INSTRUCTIONS
+        : SERVER_INSTRUCTIONS,
+    }
+  );
+
+  if (root !== undefined) {
+    registerRestrictedTools(server, root);
+  } else {
+    registerOpenTools(server);
   }
+  registerSharedTools(server);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/util.ts
+++ b/src/util.ts
@@ -87,6 +87,32 @@ export function errorMessage(error: unknown) {
   return error instanceof Error ? error.message : `${error}`;
 }
 
+export function isMalloyFile(p: string): boolean {
+  return path.extname(p).toLowerCase() === '.malloy';
+}
+
+/** Path segments the .malloy walk skips: dotfiles/dirs and node_modules. */
+export function isHiddenPathSegment(name: string): boolean {
+  return name.startsWith('.') || name === 'node_modules';
+}
+
+export function findMalloyFiles(dir: string): string[] {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, {withFileTypes: true});
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const entry of entries) {
+    if (isHiddenPathSegment(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...findMalloyFiles(full));
+    else if (entry.isFile() && isMalloyFile(full)) out.push(full);
+  }
+  return out;
+}
+
 // Matches DuckDB's file-lock error. DuckDB doesn't expose a typed error code
 // for this; the message is the only signal.
 const DUCKDB_LOCK_ERROR = /Could not set lock on file/;

--- a/test/mcp/restricted.spec.ts
+++ b/test/mcp/restricted.spec.ts
@@ -1,0 +1,240 @@
+/* Copyright Contributors to the Malloy project / SPDX-License-Identifier: MIT */
+
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import {createBasicLogger, silenceOut} from '../../src/log';
+import {loadConfig} from '../../src/config';
+import '../../src/connections/connection_manager';
+import {
+  extractDescription,
+  resolveHandle,
+  listModels,
+  describeModel,
+  compileRestricted,
+  runRestricted,
+} from '../../src/mcp/restricted';
+
+// Inline-SQL sources keep the models self-contained — no CSV fixtures, no
+// working-directory dependency. `orders` is defined via duckdb.sql so it
+// doubles as the "a model field defined with connection.sql is still
+// referenceable from restricted text" regression.
+const PUBLISHED = `##|(mcp-description)
+Orders for the test shop.
+Two line description.
+|##
+source: orders is duckdb.sql("SELECT 1 as id, 10 as amount UNION ALL SELECT 2 as id, 20 as amount")
+`;
+
+const NESTED = `##(mcp-description) Nested model.
+source: nums is duckdb.sql("SELECT 1 as v UNION ALL SELECT 2 as v")
+`;
+
+const SECRET = `source: secret is duckdb.sql("SELECT 1 as x")
+`;
+
+const GIVENS_MODEL = `##! experimental.givens
+##|(mcp-description)
+Model with a given.
+|##
+given:
+  TARGET :: number is 0
+source: nums is duckdb.sql("SELECT 1 as v UNION ALL SELECT 2 as v UNION ALL SELECT 3 as v")
+`;
+
+describe('restricted MCP mode', () => {
+  let originalXDG: string | undefined;
+  let tempDir: string;
+  let root: string;
+
+  beforeAll(async () => {
+    originalXDG = process.env['XDG_CONFIG_HOME'];
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'malloy-cli-restricted-'));
+    const malloyDir = path.join(tempDir, 'malloy');
+    fs.mkdirSync(malloyDir, {recursive: true});
+    fs.writeFileSync(
+      path.join(malloyDir, 'malloy-config.json'),
+      JSON.stringify({connections: {duckdb: {is: 'duckdb'}}})
+    );
+    process.env['XDG_CONFIG_HOME'] = tempDir;
+
+    root = path.join(tempDir, 'models');
+    fs.mkdirSync(path.join(root, 'sub'), {recursive: true});
+    fs.writeFileSync(path.join(root, 'published.malloy'), PUBLISHED);
+    fs.writeFileSync(path.join(root, 'sub', 'nested.malloy'), NESTED);
+    fs.writeFileSync(path.join(root, 'secret.malloy'), SECRET);
+    fs.writeFileSync(path.join(root, 'givens_model.malloy'), GIVENS_MODEL);
+
+    createBasicLogger();
+    await loadConfig();
+    silenceOut();
+  });
+
+  afterAll(() => {
+    if (originalXDG !== undefined) {
+      process.env['XDG_CONFIG_HOME'] = originalXDG;
+    } else {
+      delete process.env['XDG_CONFIG_HOME'];
+    }
+    fs.rmSync(tempDir, {recursive: true, force: true});
+  });
+
+  describe('extractDescription', () => {
+    it('reads a multi-line block body', () => {
+      expect(extractDescription(PUBLISHED)).toBe(
+        'Orders for the test shop.\nTwo line description.'
+      );
+    });
+
+    it('reads a single-line marker', () => {
+      expect(extractDescription(NESTED)).toBe('Nested model.');
+    });
+
+    it('returns undefined when unmarked', () => {
+      expect(extractDescription(SECRET)).toBeUndefined();
+    });
+  });
+
+  describe('listModels', () => {
+    it('lists only marked models, with descriptions, nested handles', () => {
+      const models = listModels(root);
+      const byHandle = Object.fromEntries(
+        models.map(m => [m.handle, m.description])
+      );
+      expect(Object.keys(byHandle).sort()).toEqual([
+        'givens_model.malloy',
+        'published.malloy',
+        'sub/nested.malloy',
+      ]);
+      expect(byHandle['secret.malloy']).toBeUndefined();
+      expect(byHandle['published.malloy']).toBe(
+        'Orders for the test shop.\nTwo line description.'
+      );
+      expect(byHandle['sub/nested.malloy']).toBe('Nested model.');
+    });
+  });
+
+  describe('resolveHandle', () => {
+    it('accepts a marked model (including nested)', () => {
+      expect(resolveHandle(root, 'published.malloy')).toHaveProperty('abs');
+      expect(resolveHandle(root, 'sub/nested.malloy')).toHaveProperty('abs');
+    });
+
+    it.each([
+      ['unmarked model', 'secret.malloy'],
+      ['parent traversal', '../escape.malloy'],
+      ['absolute path', '/etc/passwd'],
+      ['missing file', 'nope.malloy'],
+    ])('rejects %s as model-not-found', (_label, handle) => {
+      const res = resolveHandle(root, handle);
+      expect(res).not.toHaveProperty('abs');
+      if ('problem' in res) {
+        expect(res.problem.code).toBe('model-not-found');
+      }
+    });
+  });
+
+  describe('describe_model', () => {
+    it('returns the curated surface of a published model', async () => {
+      const res = await describeModel(root, 'published.malloy');
+      expect(res.ok).toBe(true);
+      expect(res.model?.sources.map(s => s.name)).toContain('orders');
+    });
+
+    it('refuses an unpublished model', async () => {
+      const res = await describeModel(root, 'secret.malloy');
+      expect(res.ok).toBe(false);
+      expect(res.problems[0].code).toBe('model-not-found');
+    });
+  });
+
+  describe('compileRestricted', () => {
+    it('accepts a clean query', async () => {
+      const res = await compileRestricted(
+        root,
+        'published.malloy',
+        'run: orders -> { aggregate: total is amount.sum() }'
+      );
+      expect(res.problems.filter(p => p.severity === 'error')).toEqual([]);
+      expect(res.ok).toBe(true);
+    });
+
+    it.each([
+      ['import', 'import "secret.malloy"\nrun: orders -> { select: id }'],
+      ['connection.table', "run: duckdb.table('x') -> { select: a }"],
+      ['connection.sql', 'run: duckdb.sql("select 1 as a") -> { select: a }'],
+      ['sql_ function', 'run: orders -> { select: n is sql_number("1") }'],
+      ['##! flag', '##! experimental.foo\nrun: orders -> { select: id }'],
+    ])('rejects %s with restricted-construct-forbidden', async (_l, query) => {
+      const res = await compileRestricted(root, 'published.malloy', query);
+      expect(res.ok).toBe(false);
+      expect(
+        res.problems.some(p => p.code === 'restricted-construct-forbidden')
+      ).toBe(true);
+    });
+
+    // `given:` needs the experimental flag the model enables; without it the
+    // feature gate fires before the restricted check, so test it against the
+    // givens-enabled model.
+    it('rejects a given: declaration with restricted-construct-forbidden', async () => {
+      const res = await compileRestricted(
+        root,
+        'givens_model.malloy',
+        'given: X :: number is 1\nrun: nums -> { select: v }'
+      );
+      expect(res.ok).toBe(false);
+      expect(
+        res.problems.some(p => p.code === 'restricted-construct-forbidden')
+      ).toBe(true);
+    });
+
+    it('reports multiple violations in one compile', async () => {
+      const res = await compileRestricted(
+        root,
+        'published.malloy',
+        'import "secret.malloy"\nrun: duckdb.table(\'x\') -> { select: a }'
+      );
+      const restricted = res.problems.filter(
+        p => p.code === 'restricted-construct-forbidden'
+      );
+      expect(restricted.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('runRestricted', () => {
+    it('runs a clean query referencing a connection.sql-defined source', async () => {
+      const res = await runRestricted(
+        root,
+        'published.malloy',
+        'run: orders -> { aggregate: total is amount.sum() }'
+      );
+      expect(res.ok).toBe(true);
+      expect(res.rowCount).toBe(1);
+      expect((res.rows?.[0] as {total: number}).total).toBe(30);
+    });
+
+    it('threads givens through to the query', async () => {
+      const res = await runRestricted(
+        root,
+        'givens_model.malloy',
+        'run: nums -> { select: v; where: v = $TARGET }',
+        {givens: {TARGET: 2}}
+      );
+      expect(res.ok).toBe(true);
+      expect(res.rowCount).toBe(1);
+      expect((res.rows?.[0] as {v: number}).v).toBe(2);
+    });
+
+    it('refuses a forbidden construct at run time', async () => {
+      const res = await runRestricted(
+        root,
+        'published.malloy',
+        "run: duckdb.table('x') -> { select: a }"
+      );
+      expect(res.ok).toBe(false);
+      expect(
+        res.problems.some(p => p.code === 'restricted-construct-forbidden')
+      ).toBe(true);
+    });
+  });
+});

--- a/test/mcp/restricted.spec.ts
+++ b/test/mcp/restricted.spec.ts
@@ -60,10 +60,19 @@ describe('restricted MCP mode', () => {
 
     root = path.join(tempDir, 'models');
     fs.mkdirSync(path.join(root, 'sub'), {recursive: true});
+    fs.mkdirSync(path.join(root, '.hidden'), {recursive: true});
     fs.writeFileSync(path.join(root, 'published.malloy'), PUBLISHED);
     fs.writeFileSync(path.join(root, 'sub', 'nested.malloy'), NESTED);
     fs.writeFileSync(path.join(root, 'secret.malloy'), SECRET);
     fs.writeFileSync(path.join(root, 'givens_model.malloy'), GIVENS_MODEL);
+    // A marked model saved with CRLF line endings must still publish.
+    fs.writeFileSync(
+      path.join(root, 'crlf.malloy'),
+      PUBLISHED.replace(/\n/g, '\r\n')
+    );
+    // A marked model inside a hidden dir is excluded from the walk — and must
+    // also be unreachable, so listing and reachability stay in lockstep.
+    fs.writeFileSync(path.join(root, '.hidden', 'buried.malloy'), PUBLISHED);
 
     createBasicLogger();
     await loadConfig();
@@ -102,11 +111,13 @@ describe('restricted MCP mode', () => {
         models.map(m => [m.handle, m.description])
       );
       expect(Object.keys(byHandle).sort()).toEqual([
+        'crlf.malloy',
         'givens_model.malloy',
         'published.malloy',
         'sub/nested.malloy',
       ]);
       expect(byHandle['secret.malloy']).toBeUndefined();
+      expect(byHandle['.hidden/buried.malloy']).toBeUndefined();
       expect(byHandle['published.malloy']).toBe(
         'Orders for the test shop.\nTwo line description.'
       );
@@ -115,9 +126,10 @@ describe('restricted MCP mode', () => {
   });
 
   describe('resolveHandle', () => {
-    it('accepts a marked model (including nested)', () => {
+    it('accepts a marked model (including nested and CRLF)', () => {
       expect(resolveHandle(root, 'published.malloy')).toHaveProperty('abs');
       expect(resolveHandle(root, 'sub/nested.malloy')).toHaveProperty('abs');
+      expect(resolveHandle(root, 'crlf.malloy')).toHaveProperty('abs');
     });
 
     it.each([
@@ -125,6 +137,7 @@ describe('restricted MCP mode', () => {
       ['parent traversal', '../escape.malloy'],
       ['absolute path', '/etc/passwd'],
       ['missing file', 'nope.malloy'],
+      ['hidden-dir model', '.hidden/buried.malloy'],
     ])('rejects %s as model-not-found', (_label, handle) => {
       const res = resolveHandle(root, handle);
       expect(res).not.toHaveProperty('abs');


### PR DESCRIPTION
## TL;DR — publish a restricted set of queries

Point the MCP server at a directory of models and let an agent query them, without giving it the keys to the database.

1. Put your `.malloy` models in a dir with a `malloy-config.json` (your connections).
2. Mark the ones you want to expose with a description annotation:
   ```malloy
   ##|(mcp-description)
   Orders by day, region, and product. Ask about revenue, counts, trends.
   |##
   source: orders is duckdb.table('orders')
   ```
3. Run it restricted:
   ```
   malloy-cli -p ./my-models mcp --restricted
   ```

Now the agent sees `list_models` / `describe_model` / `compile` / `run` and nothing else. It selects a model by handle and writes Malloy against it — but `import`, `connection.table/sql`, `name!type(...)`, the `sql_*` functions, `given:` declarations, and `##!` flags are all rejected (`restricted-construct-forbidden`). Unmarked models are invisible and unreachable. The worst it can do is ask a question your published models already allow.

Enforcement is malloy core's `loadRestrictedQuery`; this PR is the CLI/MCP wiring around it. Without `--restricted` the server is exactly as it was.