### PR TITLE
ci: bump actions off deprecated node20 runtime

### DIFF
--- a/.github/workflows/debug-codeql.yml
+++ b/.github/workflows/debug-codeql.yml
@@ -62,7 +62,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -72,7 +72,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -91,6 +91,6 @@ jobs:
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
     
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -25,15 +25,15 @@ jobs:
       packages: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
       - name: Upgrade npm for trusted publishing (OIDC)
         run: npm install -g npm@latest
       
-      - uses: 'google-github-actions/auth@v2'
+      - uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.BIGQUERY_KEY }}'
       
@@ -87,22 +87,22 @@ jobs:
     steps:
       - name: Generate token from GitHub App
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.NPM_ACTIONS_APP_ID }}
           private-key: ${{ secrets.NPM_ACTIONS_PRIVATE_KEY }}
       
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
       
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
       - name: Upgrade npm for trusted publishing (OIDC)
         run: npm install -g npm@latest
       
-      - uses: 'google-github-actions/auth@v2'
+      - uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.BIGQUERY_KEY }}'
       

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,15 +20,15 @@ jobs:
           error_message: |
             User does not have write access to this repository. Refer to CONTRIBUTING.md instructions on how to contribute to Malloy.
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: GCloud auth
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.BIGQUERY_KEY }}'
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
       - name: Install


### PR DESCRIPTION
GitHub's node20 Actions runtime is deprecated — every action whose `runs.using` is `node20` now emits a deprecation warning and will eventually hard-fail. I scanned all three workflows and bumped each third-party action to its node24 major.

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `google-github-actions/auth` | v2 | v3 |
| `actions/create-github-app-token` | v1 | v3 |
| `github/codeql-action/{init,analyze}` | v3 | v4 |

A couple of things I checked so the bumps don't break CI: `credentials_json` is still a valid input on `auth@v3`, and `create-github-app-token@v2` is *still* node20 — v3 is the first node24 release, so that one jumps two majors. The setup-node v5+ automatic-npm-cache behavior is non-breaking for our `npm ci` flow.

One node20 action remains that I can't fix from here: `malloydata/check-ci-permissions@v1` in `.github/workflows/test.yaml`. Its `v1` tag is built on node20, so it needs a node24 release in that action's own repo before the reference can move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)