### PR TITLE
Handle .malloy files with no queries gracefully

### DIFF
--- a/src/malloy/malloy.ts
+++ b/src/malloy/malloy.ts
@@ -66,7 +66,27 @@ export async function runMalloy(
             );
             break;
         }
-      } else query = modelMaterializer.loadFinalQuery();
+      } else {
+        // No query specified: default to the model's final query. A model
+        // with no queries at all isn't an error — compiling it still
+        // validates the model, and running it simply has nothing to do.
+        const model = await modelMaterializer.getModel();
+        const {named, unnamed} = model.queries();
+        if (named.length + unnamed === 0) {
+          if (options.compileOnly) {
+            // Compiling validates the model; with nothing to run that's a
+            // clean success.
+            resultsLog.malloy(
+              'Model compiled successfully (no queries to compile).'
+            );
+            return JSON.stringify(json);
+          }
+          // Asking to run a model with nothing to run is an error: report it
+          // to stderr and exit non-zero.
+          resultsLog.error('Nothing to run: this model has no queries.');
+        }
+        query = modelMaterializer.loadFinalQuery();
+      }
 
       const givensOpt = options.givens ? {givens: options.givens} : {};
       const sql = await query.getSQL(givensOpt);

--- a/test/files/no_queries.malloy
+++ b/test/files/no_queries.malloy
@@ -1,0 +1,1 @@
+source: nums is duckdb.sql("SELECT 1 as one")

--- a/test/malloy/malloy.spec.ts
+++ b/test/malloy/malloy.spec.ts
@@ -45,6 +45,23 @@ describe('Malloy', () => {
     // TODO
   });
 
+  describe('no queries', () => {
+    const fixture = path.resolve(
+      path.join(__dirname, '..', 'files', 'no_queries.malloy')
+    );
+
+    it('compiles a file with no queries without erroring', async () => {
+      const out = await runMalloy(fixture, {compileOnly: true, json: true});
+      expect(JSON.parse(out as string)).not.toHaveProperty('error');
+    });
+
+    it('errors when asked to run a file with no queries', async () => {
+      await expect(
+        runMalloy(fixture, {compileOnly: false, json: true})
+      ).rejects.toThrow('Nothing to run: this model has no queries.');
+    });
+  });
+
   describe('givens', () => {
     const fixture = path.resolve(
       path.join(__dirname, '..', 'files', 'givens_sql.malloy')


### PR DESCRIPTION
Compiling or running a `.malloy` file with no queries threw core's `Model has no queries.` wrapped as `Internal compiler error (likely a Malloy bug — please file an issue)`. The no-query default path went straight to `loadFinalQuery()`.

Now the no-selector path checks `model.queries()` first. A model with no queries of any kind:

- **compile** → still fully compiles/validates the model, then reports `Model compiled successfully (no queries to compile).` and exits 0.
- **run** → `Error: Nothing to run: this model has no queries.` on stderr, exit 1.

