### PR TITLE
Keep major bumps out of the weekly Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     groups:
-      all-dependencies:
+      minor-and-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
The `all-dependencies` group from #215 bundled major bumps in with the safe ones. The first weekly run (#216) pulled `typescript@6`, `gts@7`, `@typescript-eslint@8`, and the eslint/prettier majors into the same PR as 28 harmless patch/minor updates — and one breaking major makes the whole pile unmergeable, with no way to peel the safe bumps out.

Restrict the group to `minor` + `patch`. Majors now come as their own individual PRs, handled deliberately, without blocking the weekly batch.