### PR TITLE
Refine Dependabot grouping (duckdb + toolchain) and document CI in .github/CONTEXT.md

### DIFF
--- a/.github/CONTEXT.md
+++ b/.github/CONTEXT.md
@@ -1,0 +1,54 @@
+# .github — CONTEXT.md
+
+CI (`test.yaml`), npm release (`npm-publish.yml`), and Dependabot (`dependabot.yml`).
+Non-obvious things; the YAML says what each step runs.
+
+## The CI permission gate is intentional — never bypass it
+
+`test.yaml` runs on `pull_request_target`, which executes in the base-repo context *with
+secrets* (the `BIGQUERY_KEY` the live-backend suite needs). Its first step,
+`malloydata/check-ci-permissions`, hard-fails in ~5s for any actor without write access —
+**including `dependabot[bot]` and fork PRs**. That red is by design: auto-running an
+untrusted PR's code (a transitive dep's install script) with the BigQuery key is the
+supply-chain hole the gate closes.
+
+The check reads `github.triggering_actor`, so a maintainer clicking **"Re-run jobs"**
+becomes the actor and the real suite runs. **The re-run IS the approval.** Do not add a
+`dependabot[bot]` exception — that re-opens the hole. Normal Dependabot flow: bot PR lands
+red → maintainer re-runs to vouch → green → merge.
+
+Tell: a `test-all` that fails in ~5s was rejected at the gate (tests never ran); a
+multi-minute run got past it.
+
+## Dependabot grouping rationale
+
+Group order matters — a dep lands in the *first* matching group.
+
+- **Majors stay OUT of the weekly `minor-and-patch` group.** One breaking major (e.g. a lib
+  that ships a breaking change in a *minor*, as logform did at 2.7) would otherwise make the
+  whole weekly pile unmergeable. Ungrouped majors arrive as individual PRs, handled
+  deliberately.
+- **`@duckdb/*` is its own group.** Not because it's the only native connector — Databricks
+  pulls a native addon too (`@databricks/sql` → `lz4`, transitively via
+  `@malloydata/malloy-connections`). DuckDB is special because it's the only dep whose
+  per-platform binaries are *direct* deps: standalone-binary packaging forces every
+  `@duckdb/node-bindings-{platform}` into `optionalDependencies` (see root `CONTEXT.md`), so
+  one bump fragments into 8 separate Dependabot PRs. Transitive native bits like `lz4` never
+  fragment, so they need no group. The group collapses the 8 into one PR; the exact
+  prerelease pins (`1.5.3-r.2`) also keep them out of the minor/patch pile.
+- **`toolchain` majors are grouped.** `gts` is a meta-package pinning
+  `eslint`/`@typescript-eslint`/`prettier`/`typescript`, so their *majors* must move together
+  or none lints. Minors/patches fall through to the weekly pile.
+
+Gotchas:
+- Pushing a commit onto a Dependabot PR branch (e.g. to fold in a fix for a semver-breaking
+  bump) makes Dependabot **stop managing** it — no more rebases/recreates. Fine right before
+  merge.
+- Stale superseded PRs squat on `open-pull-requests-limit` slots and block new ones
+  ("Dependabot cannot open any more pull requests"). Close them promptly.
+
+## npm publish cuts a release on every merge
+
+`npm-publish.yml` publishes `@next` on **every push to `main`**, so each merge — including
+each Dependabot merge — ships a `@next`. Weekly grouping keeps that to ~1/week. `@latest` is
+manual only (`workflow_dispatch`, patch bump, behind the `malloy-ci-npm-publisher` app token).

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,14 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     groups:
+      duckdb:
+        patterns:
+          - "@duckdb/*"
       minor-and-patch:
         patterns:
           - "*"
+        exclude-patterns:
+          - "@duckdb/*"
         update-types:
           - "minor"
           - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,16 @@ updates:
       duckdb:
         patterns:
           - "@duckdb/*"
+      toolchain:
+        patterns:
+          - "gts"
+          - "typescript"
+          - "eslint"
+          - "eslint-*"
+          - "@typescript-eslint/*"
+          - "prettier"
+        update-types:
+          - "major"
       minor-and-patch:
         patterns:
           - "*"

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,7 +5,8 @@ Thin CLI on top of `@malloydata/malloy` and `@malloydata/malloy-connections`. Pu
 
 This file lists things that aren't obvious from reading the code: invariants, silent
 gotchas, decisions whose rationale isn't in any commit message, cross-cutting "don't do
-this" warnings. For layout, scripts, deps, etc. — read the tree.
+this" warnings. For layout, scripts, deps, etc. — read the tree. CI, release, and Dependabot
+specifics live in `.github/CONTEXT.md`.
 
 ## Build output filename quirk
 


### PR DESCRIPTION
Two grouping refinements plus the CI/release docs that were missing.

**duckdb group** — a single duckdb bump (`1.5.3-r.2 → 1.5.3-r.3`) fragments across its 8 platform-specific binding packages and eats most of the PR-limit. Group all `@duckdb/*` into one PR (any update type). DuckDB is the only native connector — BigQuery/Postgres/Snowflake/Trino are pure-JS network clients — so this is a group of one by design, not a "native connectors" bucket waiting for peers.

**toolchain group** — `gts` is a meta-package pinning `eslint`/`@typescript-eslint`/`prettier`/`typescript`, so their majors must move together or none lints. Group their *major* bumps; minors/patches still fall through to the weekly minor-and-patch pile.

**.github/CONTEXT.md** — the `.github` dir had no CONTEXT. Documents the non-obvious parts: the `check-ci-permissions` gate is an intentional re-run-to-vouch approval (a red Dependabot PR is expected; never bypass it for the bot, or `pull_request_target` hands the BigQuery key to untrusted code), the grouping rationale above, and that `npm-publish` ships `@next` on every push to main. Linked from the root CONTEXT.md.