### PR TITLE
Add native-dependency guard to malloy-update

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -118,6 +118,15 @@ It is not a plain `npm update` — three steps in order:
    installed `@malloydata/db-duckdb`'s `@duckdb/node-api` wants. Keeping these in lockstep
    is what stops the standalone binary from loading a mismatched native lib.
 3. A final `npm install` to reconcile the lockfile.
+4. `npm run check-native` — fails if the re-resolved lockfile gained a native package
+   (lockfile entry with `os`/`cpu`, or `hasInstallScript`) not listed in
+   `scripts/approved-native-deps.json`. Re-resolution can float an unpinned transitive dep
+   to a version that ships a `.node` binary; esbuild can't bundle those, so `npm run build`
+   breaks and it only surfaces in CI (this is how `@databricks/sql` 1.16.0 broke the
+   0.0.411 bump). When it fires, pin the dep — upstream in malloy, which owns the connector,
+   or locally — and re-run; or, if the binary is genuinely wanted, externalize it in
+   `build.ts` and ship it like the DuckDB bindings, then `npm run approve-native` to record
+   it (the per-entry `note` documents why each is approved).
 
 `malloy-update-next` is the same against the `next` (pre-release) tag. After either, run
 `npm run lint && npm run build && npm run test-silent`; if you touched DuckDB, also

--- a/package.json
+++ b/package.json
@@ -34,8 +34,10 @@
     "package-npm": "ts-node scripts/package-npm",
     "npm-publish": "ts-node scripts/npm-publish",
     "postpack": "npm run build",
-    "malloy-update-next": "npm install  --no-fund --no-audit --save-exact $(./scripts/malloy-packages.ts next) && ts-node scripts/sync-duckdb.ts && npm install --no-fund --no-audit",
-    "malloy-update": "npm install  --no-fund --no-audit --save-exact $(./scripts/malloy-packages.ts latest) && ts-node scripts/sync-duckdb.ts && npm install --no-fund --no-audit",
+    "malloy-update-next": "npm install  --no-fund --no-audit --save-exact $(./scripts/malloy-packages.ts next) && ts-node scripts/sync-duckdb.ts && npm install --no-fund --no-audit && npm run check-native",
+    "malloy-update": "npm install  --no-fund --no-audit --save-exact $(./scripts/malloy-packages.ts latest) && ts-node scripts/sync-duckdb.ts && npm install --no-fund --no-audit && npm run check-native",
+    "check-native": "ts-node scripts/check-native.ts",
+    "approve-native": "ts-node scripts/approve-native.ts",
     "malloy-link": "npm --no-fund --no-audit link $(./scripts/malloy-packages.ts)",
     "malloy-unlink": "npm --no-fund --no-save --no-audit unlink $(./scripts/malloy-packages.ts) && npm --no-fund --no-audit install --force"
   },

--- a/scripts/approve-native.ts
+++ b/scripts/approve-native.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env ts-node
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * Regenerates scripts/approved-native-deps.json from the current
+ * package-lock.json: every native package becomes an approved entry. Existing
+ * `note` text is preserved so the human-written rationale for each approval
+ * ("why is this binary ok") survives regeneration. Run this after you have
+ * deliberately accepted a new native dependency (and handled its `.node`
+ * binary in packaging). Review the resulting diff before committing.
+ */
+
+import {
+  ApprovedList,
+  collectNativePackages,
+  readApproved,
+  writeApproved,
+} from './native-deps';
+
+const native = collectNativePackages();
+const existing = readApproved();
+
+const next: ApprovedList = {};
+Array.from(native.values()).forEach(p => {
+  next[p.name] = {
+    version: p.version,
+    note: existing[p.name]?.note ?? '',
+  };
+});
+
+const added = Array.from(native.keys()).filter(name => !(name in existing));
+const removed = Object.keys(existing).filter(name => !native.has(name));
+
+writeApproved(next);
+
+console.log(
+  `approve-native: wrote ${Object.keys(next).length} approved native package(s).`
+);
+if (added.length > 0) {
+  console.log(`  added:   ${added.sort().join(', ')}`);
+}
+if (removed.length > 0) {
+  console.log(`  removed: ${removed.sort().join(', ')}`);
+}
+console.log(
+  'Review the diff in scripts/approved-native-deps.json before committing.'
+);

--- a/scripts/approved-native-deps.json
+++ b/scripts/approved-native-deps.json
@@ -1,0 +1,242 @@
+{
+  "@duckdb/node-bindings-darwin-arm64": {
+    "version": "1.5.3-r.2",
+    "note": "DuckDB native binding. Externalized in build.ts via getDuckDBExternals() and shipped as optionalDependencies by package-npm.ts; resolved at runtime, not bundled. (All @duckdb/node-bindings-* variants are handled the same way.)"
+  },
+  "@duckdb/node-bindings-darwin-x64": {
+    "version": "1.5.3-r.2",
+    "note": ""
+  },
+  "@duckdb/node-bindings-linux-arm64": {
+    "version": "1.5.3-r.2",
+    "note": ""
+  },
+  "@duckdb/node-bindings-linux-arm64-musl": {
+    "version": "1.5.3-r.2",
+    "note": ""
+  },
+  "@duckdb/node-bindings-linux-x64": {
+    "version": "1.5.3-r.2",
+    "note": ""
+  },
+  "@duckdb/node-bindings-linux-x64-musl": {
+    "version": "1.5.3-r.2",
+    "note": ""
+  },
+  "@duckdb/node-bindings-win32-arm64": {
+    "version": "1.5.3-r.2",
+    "note": ""
+  },
+  "@duckdb/node-bindings-win32-x64": {
+    "version": "1.5.3-r.2",
+    "note": ""
+  },
+  "@esbuild/aix-ppc64": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/android-arm": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/android-arm64": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/android-x64": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/darwin-arm64": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/darwin-x64": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/freebsd-arm64": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/freebsd-x64": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/linux-arm": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/linux-arm64": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/linux-ia32": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/linux-loong64": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/linux-mips64el": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/linux-ppc64": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/linux-riscv64": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/linux-s390x": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/linux-x64": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/netbsd-arm64": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/netbsd-x64": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/openbsd-arm64": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/openbsd-x64": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/openharmony-arm64": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/sunos-x64": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/win32-arm64": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/win32-ia32": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@esbuild/win32-x64": {
+    "version": "0.27.7",
+    "note": ""
+  },
+  "@unrs/resolver-binding-android-arm-eabi": {
+    "version": "1.12.2",
+    "note": ""
+  },
+  "@unrs/resolver-binding-android-arm64": {
+    "version": "1.12.2",
+    "note": ""
+  },
+  "@unrs/resolver-binding-darwin-arm64": {
+    "version": "1.12.2",
+    "note": ""
+  },
+  "@unrs/resolver-binding-darwin-x64": {
+    "version": "1.12.2",
+    "note": ""
+  },
+  "@unrs/resolver-binding-freebsd-x64": {
+    "version": "1.12.2",
+    "note": ""
+  },
+  "@unrs/resolver-binding-linux-arm-gnueabihf": {
+    "version": "1.12.2",
+    "note": ""
+  },
+  "@unrs/resolver-binding-linux-arm-musleabihf": {
+    "version": "1.12.2",
+    "note": ""
+  },
+  "@unrs/resolver-binding-linux-arm64-gnu": {
+    "version": "1.12.2",
+    "note": ""
+  },
+  "@unrs/resolver-binding-linux-arm64-musl": {
+    "version": "1.12.2",
+    "note": ""
+  },
+  "@unrs/resolver-binding-linux-loong64-gnu": {
+    "version": "1.12.2",
+    "note": ""
+  },
+  "@unrs/resolver-binding-linux-loong64-musl": {
+    "version": "1.12.2",
+    "note": ""
+  },
+  "@unrs/resolver-binding-linux-ppc64-gnu": {
+    "version": "1.12.2",
+    "note": ""
+  },
+  "@unrs/resolver-binding-linux-riscv64-gnu": {
+    "version": "1.12.2",
+    "note": ""
+  },
+  "@unrs/resolver-binding-linux-riscv64-musl": {
+    "version": "1.12.2",
+    "note": ""
+  },
+  "@unrs/resolver-binding-linux-s390x-gnu": {
+    "version": "1.12.2",
+    "note": ""
+  },
+  "@unrs/resolver-binding-linux-x64-gnu": {
+    "version": "1.12.2",
+    "note": ""
+  },
+  "@unrs/resolver-binding-linux-x64-musl": {
+    "version": "1.12.2",
+    "note": ""
+  },
+  "@unrs/resolver-binding-openharmony-arm64": {
+    "version": "1.12.2",
+    "note": ""
+  },
+  "@unrs/resolver-binding-wasm32-wasi": {
+    "version": "1.12.2",
+    "note": ""
+  },
+  "@unrs/resolver-binding-win32-arm64-msvc": {
+    "version": "1.12.2",
+    "note": ""
+  },
+  "@unrs/resolver-binding-win32-ia32-msvc": {
+    "version": "1.12.2",
+    "note": ""
+  },
+  "@unrs/resolver-binding-win32-x64-msvc": {
+    "version": "1.12.2",
+    "note": ""
+  },
+  "esbuild": {
+    "version": "0.28.0",
+    "note": ""
+  },
+  "fsevents": {
+    "version": "2.3.3",
+    "note": "macOS file-watching, optional transitive dep; not bundled."
+  },
+  "lz4": {
+    "version": "0.6.5",
+    "note": "Marked external in scripts/build.ts; resolved at runtime from the published deps."
+  },
+  "unrs-resolver": {
+    "version": "1.12.2",
+    "note": "Dev-only native resolver (lint tooling); not shipped in the bundle."
+  }
+}

--- a/scripts/check-native.ts
+++ b/scripts/check-native.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env ts-node
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * Fails if package-lock.json contains a native package (one that ships or
+ * builds a platform-specific binary) that is not listed in
+ * approved-native-deps.json. Wired into `npm run malloy-update` so a routine
+ * dependency bump that floats in a new native package is caught locally,
+ * before it reaches CI as an unbundleable ".node" esbuild error.
+ *
+ * When this fails you have two choices:
+ *   - pin the offending dependency (locally, or upstream in malloy), then
+ *     re-run; or
+ *   - accept it: handle its `.node` binary in the build/packaging, then run
+ *     `npm run approve-native` to record it.
+ */
+
+import {collectNativePackages, findParents, readApproved} from './native-deps';
+
+const native = collectNativePackages();
+const approved = readApproved();
+
+const unapproved = Array.from(native.values()).filter(
+  p => !(p.name in approved)
+);
+
+if (unapproved.length === 0) {
+  console.log(`check-native: ${native.size} native package(s), all approved.`);
+  process.exit(0);
+}
+
+console.error(
+  '\n✗ check-native: native package(s) not in scripts/approved-native-deps.json:\n'
+);
+for (const p of unapproved.sort((a, b) => a.name.localeCompare(b.name))) {
+  const constraint = [
+    p.os ? `os=${p.os.join(',')}` : '',
+    p.cpu ? `cpu=${p.cpu.join(',')}` : '',
+    p.hasInstallScript ? 'install-script' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+  console.error(`    ${p.name}@${p.version}  ${constraint}`);
+  const parents = findParents(p.name).filter(
+    parent => !parent.startsWith(p.name + '@')
+  );
+  if (parents.length > 0) {
+    console.error(`      via: ${parents.join(', ')}`);
+  }
+}
+
+console.error(
+  '\nNative packages ship .node binaries esbuild cannot bundle. Either pin the\n' +
+    'dependency (locally or upstream in malloy) and re-run, or handle its binary\n' +
+    'in packaging and run `npm run approve-native` to record it.\n'
+);
+process.exit(1);

--- a/scripts/native-deps.ts
+++ b/scripts/native-deps.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env ts-node
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * Shared helpers for the native-dependency guard.
+ *
+ * A "native" package is one that ships or builds a platform-specific binary:
+ * in package-lock.json those entries carry an `os`/`cpu` constraint (the
+ * modern prebuilt-binary pattern, e.g. @duckdb/node-bindings-darwin-arm64) or
+ * `hasInstallScript: true` (node-gyp build-from-source). esbuild cannot bundle
+ * the `.node` files such packages contain, so a new one appearing silently in
+ * the dependency tree breaks the extension build. We track the approved set in
+ * approved-native-deps.json and fail `malloy-update` when an unapproved native
+ * package shows up.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+export const APPROVED_FILE = path.join(__dirname, 'approved-native-deps.json');
+const LOCK_FILE = path.join(__dirname, '..', 'package-lock.json');
+
+export interface ApprovedEntry {
+  version: string;
+  note: string;
+}
+
+export type ApprovedList = Record<string, ApprovedEntry>;
+
+export interface NativePackage {
+  name: string;
+  version: string;
+  os?: string[];
+  cpu?: string[];
+  hasInstallScript?: boolean;
+}
+
+interface LockPackage {
+  version?: string;
+  os?: string[];
+  cpu?: string[];
+  hasInstallScript?: boolean;
+  dependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+}
+
+// The bare package name is whatever follows the last "node_modules/" segment,
+// so "node_modules/@scope/name/node_modules/@s/n" -> "@s/n".
+function bareName(lockPath: string): string {
+  const idx = lockPath.lastIndexOf('node_modules/');
+  return idx === -1 ? lockPath : lockPath.slice(idx + 'node_modules/'.length);
+}
+
+export function readLock(): Record<string, LockPackage> {
+  const lock = JSON.parse(fs.readFileSync(LOCK_FILE, 'utf8'));
+  return lock.packages ?? {};
+}
+
+// Every native package in the current lockfile, keyed by bare name. When the
+// same name appears at multiple paths (it shouldn't differ), the last wins —
+// versions of a given native package are consistent across the tree in practice.
+export function collectNativePackages(): Map<string, NativePackage> {
+  const packages = readLock();
+  const found = new Map<string, NativePackage>();
+  for (const [lockPath, meta] of Object.entries(packages)) {
+    if (lockPath === '') continue; // the root project
+    const isNative =
+      (Array.isArray(meta.os) && meta.os.length > 0) ||
+      (Array.isArray(meta.cpu) && meta.cpu.length > 0) ||
+      meta.hasInstallScript === true;
+    if (!isNative) continue;
+    const name = bareName(lockPath);
+    found.set(name, {
+      name,
+      version: meta.version ?? '',
+      os: meta.os,
+      cpu: meta.cpu,
+      hasInstallScript: meta.hasInstallScript,
+    });
+  }
+  return found;
+}
+
+// Best-effort: which installed package lists `name` among its (optional)
+// dependencies. Used only to make the failure message more actionable.
+export function findParents(name: string): string[] {
+  const packages = readLock();
+  const parents = new Set<string>();
+  for (const [lockPath, meta] of Object.entries(packages)) {
+    const deps = {...meta.dependencies, ...meta.optionalDependencies};
+    if (name in deps) {
+      const parent = lockPath === '' ? '(root project)' : bareName(lockPath);
+      parents.add(`${parent}@${meta.version ?? '?'}`);
+    }
+  }
+  return Array.from(parents);
+}
+
+export function readApproved(): ApprovedList {
+  if (!fs.existsSync(APPROVED_FILE)) return {};
+  return JSON.parse(fs.readFileSync(APPROVED_FILE, 'utf8'));
+}
+
+export function writeApproved(list: ApprovedList): void {
+  const sorted: ApprovedList = {};
+  for (const name of Object.keys(list).sort()) {
+    sorted[name] = list[name];
+  }
+  fs.writeFileSync(APPROVED_FILE, JSON.stringify(sorted, null, 2) + '\n');
+}


### PR DESCRIPTION
`npm run malloy-update` re-resolves the whole tree, so an unpinned transitive dep can float to a version that ships a native `.node` binary — which esbuild can't bundle, breaking `npm run build` with nothing to show for it until CI fails. That's what sank the 0.0.411 bump (#240, now closed): `@databricks/sql` floated 1.15.0 → 1.16.0 behind a `^1.8.4` range and pulled in eight `databricks-sql-kernel-*` binaries nobody asked for.

This adds a `check-native` step at the end of `malloy-update` that fails when the lockfile gains a native package not in an approved list, naming what floated in and how it got there. `approve-native` regenerates the list once you've decided a binary is wanted. Companion to the same guard in the extension (malloydata/malloy-vscode-extension#801); the detection is lockfile-based and identical, even though the CLI ships its native binaries as runtime `optionalDependencies` rather than bundling them.
