### PR TITLE
Dependabot: monthly cadence + group security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 10
     ignore:
       # @types/node tracks the Node major; keep it pinned to our runtime (24)
@@ -32,3 +32,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      # Security PRs fire on advisory publication, NOT the monthly schedule.
+      # This only collapses advisories that land in the same run into one PR.
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
A month of running the weekly grouped flow showed it wasn't worth the cadence: the `minor-and-patch` group kept coming up as a single bump, so each weekly PR cost a full rebase → re-run-to-vouch → merge cycle to land one update. This drops the version-update groups to monthly so the pile accumulates into a batch actually worth the ritual.

Cadence never gated security: those PRs fire on advisory publication, not `schedule.interval`. Also adds an `applies-to: security-updates` group to see whether a multi-advisory day ever collapses into one PR — it won't help a one-a-week trickle, but it's cheap to leave in.

Still a trial; the `dependabot-process` playbook keeps documenting weekly until monthly proves out and gets ported to the other repos.
