### PR TITLE
Run lint locally before tests; fix parameter-property lint error

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   },
   "scripts": {
     "lint": "tsc --noEmit && eslint .",
+    "pretest": "npm run lint",
     "test": "NODE_ENV=test jest --projects jest.config.js --runInBand",
+    "pretest-silent": "npm run lint",
     "test-silent": "NODE_ENV=test JEST_SILENT_REPORTER_SHOW_PATHS=true jest  --projects jest.config.js --runInBand --reporters jest-silent-reporter",
     "test-e2e": "npm run package-npm test > /dev/null 2>&1 && NODE_ENV=test jest --projects=jest-e2e.config.js --runInBand",
     "test-silent-e2e": "npm run package-npm test > /dev/null 2>&1 && NODE_ENV=test JEST_SILENT_REPORTER_SHOW_PATHS=true jest --projects=jest-e2e.config.js --runInBand --reporters jest-silent-reporter",

--- a/src/malloy/malloySQL.ts
+++ b/src/malloy/malloySQL.ts
@@ -17,13 +17,10 @@ import {
 } from './util';
 
 class VirtualURIFileHandler implements URLReader {
-  private uriReader: URLReader;
   private url: URL = new URL('malloy://internal');
   private contents: string = '';
 
-  constructor(uriReader: URLReader) {
-    this.uriReader = uriReader;
-  }
+  constructor(private uriReader: URLReader) {}
 
   public setVirtualFile(url: URL, contents: string): void {
     this.url = url;


### PR DESCRIPTION
## Why

The eslint `parameter-property` warning in `src/malloy/malloySQL.ts` only surfaced at `npm publish` time. CI runs `npm run lint`, but the local `npm test` never did — so lint failures hide until publish.

## What

- Add `pretest` / `pretest-silent` hooks (`npm run lint`) so the same lint check CI uses gates the local test run and fails fast before jest.
- Fix the existing violation: collapse `VirtualURIFileHandler`'s constructor into a parameter property. Behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)